### PR TITLE
[codex] Add Level 1 flow simulation

### DIFF
--- a/poopopulous-3000/index.html
+++ b/poopopulous-3000/index.html
@@ -49,6 +49,7 @@
     }
     .btn:hover { background: #6d4c41; }
     .btn.active { background: #a1887f; border-color: #ffd24a; }
+    .hidden { display: none; }
 
     #zoom {
       position: fixed;
@@ -94,6 +95,9 @@
   <div id="hud">
     <h1>POOPOPULOUS 3000 <small>est. 2023</small></h1>
     <div id="counter">💩 × 0</div>
+    <button id="startLevelBtn" class="btn">🚽 Start Level 1</button>
+    <button id="backBtn" class="btn hidden">← Back to Splash</button>
+    <button id="regenBtn" class="btn hidden">🔁 Regenerate Level</button>
     <button id="unleashBtn" class="btn">🌊 Unleash the Poos!</button>
     <button id="karaokeBtn" class="btn">🎤 Karaoke Mode</button>
     <button id="muteBtn" class="btn">🔊 Sound On</button>

--- a/poopopulous-3000/scripts/smoke-test.mjs
+++ b/poopopulous-3000/scripts/smoke-test.mjs
@@ -1,16 +1,35 @@
 // Drives the game in headless Chrome: collects console errors and takes
-// screenshots of the pile, the unleash mode, and karaoke mode.
+// screenshots of the pile, unleash mode, karaoke mode, and Level 1 flow.
+import { existsSync } from 'node:fs';
 import puppeteer from 'puppeteer-core';
 
 // Defaults to Vite's dev-server port (`npm run dev`). Override with GAME_URL
 // to test a `npm run preview` build or the live site.
 const URL = process.env.GAME_URL ?? 'http://localhost:5173/';
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const chromeCandidates = [
+  process.env.CHROME_PATH,
+  '/usr/bin/google-chrome-stable',
+  '/usr/bin/chromium',
+  '/usr/bin/google-chrome',
+].filter(Boolean);
+const executablePath = chromeCandidates.find((path) => existsSync(path));
+
+if (!executablePath) {
+  throw new Error(`No Chrome/Chromium executable found. Checked: ${chromeCandidates.join(', ')}`);
+}
 
 const browser = await puppeteer.launch({
-  executablePath: '/usr/bin/google-chrome-stable',
+  executablePath,
   headless: 'new',
-  args: ['--no-sandbox', '--window-size=1280,800', '--autoplay-policy=no-user-gesture-required'],
+  args: [
+    '--no-sandbox',
+    '--window-size=1280,800',
+    '--autoplay-policy=no-user-gesture-required',
+    '--use-angle=swiftshader',
+    '--use-gl=angle',
+    '--enable-unsafe-swiftshader',
+  ],
   defaultViewport: { width: 1280, height: 800 },
 });
 
@@ -19,24 +38,88 @@ const errors = [];
 page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
 page.on('pageerror', (e) => errors.push(`PAGEERROR: ${e.message}`));
 
-await page.goto(URL, { waitUntil: 'load' });
-await page.waitForSelector('canvas', { timeout: 15000 });
-await sleep(8000); // let some poos fall and settle
-await page.screenshot({ path: '/tmp/poop-1-normal.png' });
+try {
+  await page.goto(URL, { waitUntil: 'load' });
+  await page.waitForSelector('canvas', { timeout: 15000 });
+  await page.waitForFunction(() => window.__game?.mode === 'splash', { timeout: 15000 });
+  await sleep(8000); // let some poos fall and settle
+  await page.screenshot({ path: '/tmp/poop-1-normal.png' });
 
-await page.click('#unleashBtn');
-await sleep(6000);
-await page.screenshot({ path: '/tmp/poop-2-unleashed.png' });
+  await page.click('#unleashBtn');
+  await sleep(6000);
+  await page.screenshot({ path: '/tmp/poop-2-unleashed.png' });
 
-await page.click('#unleashBtn'); // calm the poos
-await page.click('#karaokeBtn');
-// jump the song to the first verse so we don't wait through the intro
-await page.evaluate(() => window.__game.karaoke.seek(20));
-await sleep(3000);
-await page.screenshot({ path: '/tmp/poop-3-karaoke.png' });
+  await page.click('#unleashBtn'); // calm the poos
+  await page.click('#karaokeBtn');
+  // jump the song to the first verse so we don't wait through the intro
+  await page.evaluate(() => window.__game.karaoke.seek(20));
+  await sleep(3000);
+  await page.screenshot({ path: '/tmp/poop-3-karaoke.png' });
+  await page.click('#karaokeBtn');
 
-const counter = await page.$eval('#counter', (el) => el.textContent);
-console.log('counter:', counter);
-console.log('console errors:', errors.length ? errors : 'none');
+  await page.click('#startLevelBtn');
+  await page.waitForFunction(() => window.__game?.mode === 'level1', { timeout: 15000 });
+  await sleep(3000);
+  await page.screenshot({ path: '/tmp/poop-4-level1-dry.png' });
+  const dryMetrics = await page.evaluate(() => window.__game.level1.getMetrics());
 
-await browser.close();
+  await page.click('#unleashBtn');
+  await sleep(10000);
+  await page.screenshot({ path: '/tmp/poop-5-level1-flow-10s.png' });
+  await sleep(8000);
+  await page.screenshot({ path: '/tmp/poop-6-level1-flow-18s.png' });
+
+  const counter = await page.$eval('#counter', (el) => el.textContent);
+  const metrics = await page.evaluate(() => window.__game.level1.getMetrics());
+  console.log('counter:', counter);
+  console.log('level1 dry metrics:', JSON.stringify(dryMetrics, null, 2));
+  console.log('level1 metrics:', JSON.stringify(metrics, null, 2));
+  console.log('console errors:', errors.length ? errors : 'none');
+
+  if (errors.length) {
+    throw new Error(`Console/page errors:\n${errors.join('\n')}`);
+  }
+
+  if (metrics.activeParticles < 1200) {
+    throw new Error(`Expected Level 1 fluid to emit at least 1200 particles, got ${metrics.activeParticles}`);
+  }
+
+  if (dryMetrics.prePooCount < 1) {
+    throw new Error(`Expected dry Level 1 to spawn physical poos, got ${dryMetrics.prePooCount}`);
+  }
+
+  if (metrics.maxNodeDegree > 4 || metrics.overfullNodes > 0 || metrics.junctionOverfull > 0) {
+    throw new Error(`Pipe routing produced invalid crossing nodes: ${JSON.stringify(metrics)}`);
+  }
+
+  if (metrics.junctionCorners < 1 || metrics.junctionTees < 1 || metrics.junctionCrosses < 1) {
+    throw new Error(`Expected corner, tee, and cross pipe nodes: ${JSON.stringify(metrics)}`);
+  }
+
+  if (metrics.renderedFittings !== metrics.junctionCorners) {
+    throw new Error(`Expected only corner nodes to render elbow fittings: ${JSON.stringify(metrics)}`);
+  }
+
+  if (metrics.drainedParticles < 1) {
+    throw new Error(`Expected Level 1 fluid to drain off-screen, got ${metrics.drainedParticles}`);
+  }
+
+  if (metrics.multiPathTransferCount < 1 || metrics.offPrimaryTransferCount < 1) {
+    throw new Error(`Expected fluid to use visible alternate pipe paths: ${JSON.stringify(metrics)}`);
+  }
+
+  if (metrics.flowDragPairCount < 1 || metrics.flowDragImpulse <= 0 || metrics.entrainmentImpulse <= 0) {
+    throw new Error(`Expected moving and stagnant fluid to exchange drag: ${JSON.stringify(metrics)}`);
+  }
+
+  if (metrics.exitSignPoopulation !== metrics.drainedParticles || !metrics.exitSignText.startsWith('Poopulation ')) {
+    throw new Error(`Exit sign did not track drained particles: ${JSON.stringify(metrics)}`);
+  }
+
+  const outsideRatio = metrics.outsidePipeCount / Math.max(metrics.activeParticles, 1);
+  if (outsideRatio > 0.01 || metrics.maxOutsideDistance > 0.18) {
+    throw new Error(`Fluid escaped pipe bounds: ${JSON.stringify(metrics)}`);
+  }
+} finally {
+  await browser.close();
+}

--- a/poopopulous-3000/src/level1/constants.js
+++ b/poopopulous-3000/src/level1/constants.js
@@ -1,0 +1,21 @@
+export const LEVEL_COLS = 14;
+export const LEVEL_ROWS = 10;
+export const PIPE_TILE_SIZE = 1.15;
+export const PIPE_INNER_RADIUS = 0.38;
+export const PIPE_WALL_THICKNESS = 0.08;
+export const PIPE_RADIUS = PIPE_INNER_RADIUS + PIPE_WALL_THICKNESS;
+export const SLOPE_DROP_PER_ROW = 0.16;
+
+export const MAX_FLUID_PARTICLES = 3000;
+export const FLOW_EMIT_RATE = 260;
+export const PARTICLES_PER_PRE_POO = 80;
+export const PARTICLE_RADIUS = 0.075;
+export const SMOOTHING_RADIUS = 0.24;
+export const BOUNDARY_SKIN = 0.035;
+export const LEAK_SNAP_DISTANCE = 0.18;
+export const SPH_SUBSTEPS = 2;
+
+export const PRE_UNLEASH_INTERVAL = 950;
+export const MAX_PRE_UNLEASH_POOS = 24;
+export const MAX_FLOATERS = 18;
+export const FLOATER_SCALE = 0.32;

--- a/poopopulous-3000/src/level1/exitSign.js
+++ b/poopopulous-3000/src/level1/exitSign.js
@@ -1,0 +1,258 @@
+import * as THREE from 'three';
+import { PIPE_TILE_SIZE } from './constants.js';
+
+const CANVAS_WIDTH = 1024;
+const CANVAS_HEIGHT = 512;
+const SIGN_WIDTH = 4.25;
+const SIGN_HEIGHT = 1.96;
+const SIGN_LIFT = 1.78;
+
+function arrowPoints(direction = 1) {
+  const points = [
+    [70, 150],
+    [650, 150],
+    [650, 78],
+    [958, 256],
+    [650, 434],
+    [650, 362],
+    [70, 362],
+  ];
+
+  if (direction === 1) return points;
+  return points.map(([x, y]) => [CANVAS_WIDTH - x, y]);
+}
+
+function tracePolygon(ctx, points, inset = 0) {
+  const centerX = CANVAS_WIDTH / 2;
+  const centerY = CANVAS_HEIGHT / 2;
+  ctx.beginPath();
+  points.forEach(([x, y], index) => {
+    const dx = x - centerX;
+    const dy = y - centerY;
+    const len = Math.max(Math.hypot(dx, dy), 0.0001);
+    const px = x - (dx / len) * inset;
+    const py = y - (dy / len) * inset;
+    if (index === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  });
+  ctx.closePath();
+}
+
+function drawBulb(ctx, x, y, size, phase) {
+  const glow = ctx.createRadialGradient(x, y, 1, x, y, size * 2.2);
+  glow.addColorStop(0, 'rgba(255, 252, 209, 0.88)');
+  glow.addColorStop(0.35, 'rgba(255, 184, 74, 0.42)');
+  glow.addColorStop(1, 'rgba(255, 128, 20, 0)');
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(x, y, size * 2.2, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = phase % 2 === 0 ? '#fff6b7' : '#ffd27a';
+  ctx.strokeStyle = '#8e2e13';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.arc(x, y, size, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+}
+
+function drawBulbs(ctx, points) {
+  let phase = 0;
+  const spacing = 43;
+
+  for (let i = 0; i < points.length; i++) {
+    const [x1, y1] = points[i];
+    const [x2, y2] = points[(i + 1) % points.length];
+    const length = Math.hypot(x2 - x1, y2 - y1);
+    const count = Math.max(1, Math.floor(length / spacing));
+
+    for (let j = 0; j < count; j++) {
+      const t = (j + 0.5) / count;
+      drawBulb(ctx, x1 + (x2 - x1) * t, y1 + (y2 - y1) * t, 10, phase++);
+    }
+  }
+}
+
+function fitText(ctx, text, maxWidth, startSize, weight = '800') {
+  let size = startSize;
+  do {
+    ctx.font = `${weight} ${size}px Arial, Helvetica, sans-serif`;
+    if (ctx.measureText(text).width <= maxWidth) return size;
+    size -= 4;
+  } while (size > 22);
+
+  return size;
+}
+
+function drawSignFace(ctx, drainedParticles, direction = 1) {
+  const points = arrowPoints(direction);
+  const populationText = `Poopulation ${Math.floor(drainedParticles).toLocaleString()}`;
+  const textX = direction === 1 ? 390 : CANVAS_WIDTH - 390;
+
+  ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  ctx.save();
+  ctx.shadowColor = 'rgba(0, 0, 0, 0.42)';
+  ctx.shadowBlur = 18;
+  ctx.shadowOffsetX = 12;
+  ctx.shadowOffsetY = 16;
+  tracePolygon(ctx, points);
+  ctx.fillStyle = '#7a1f18';
+  ctx.fill();
+  ctx.restore();
+
+  tracePolygon(ctx, points);
+  ctx.fillStyle = '#b52a1d';
+  ctx.fill();
+
+  tracePolygon(ctx, points, 28);
+  ctx.fillStyle = '#fff3c7';
+  ctx.fill();
+
+  tracePolygon(ctx, points, 52);
+  ctx.fillStyle = '#107aa4';
+  ctx.fill();
+
+  ctx.save();
+  tracePolygon(ctx, points, 52);
+  ctx.clip();
+  const stripe = ctx.createLinearGradient(0, 100, 0, 420);
+  stripe.addColorStop(0, 'rgba(255,255,255,0.18)');
+  stripe.addColorStop(0.5, 'rgba(255,255,255,0)');
+  stripe.addColorStop(1, 'rgba(0,0,0,0.2)');
+  ctx.fillStyle = stripe;
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+  ctx.restore();
+
+  drawBulbs(ctx, points);
+
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.lineJoin = 'round';
+
+  const titleSize = fitText(ctx, 'Poopopulous', 590, 86, '900');
+  ctx.font = `900 ${titleSize}px Arial Black, Arial, Helvetica, sans-serif`;
+  ctx.lineWidth = 12;
+  ctx.strokeStyle = '#7b241b';
+  ctx.strokeText('Poopopulous', textX, 226);
+  ctx.fillStyle = '#ffe9a8';
+  ctx.fillText('Poopopulous', textX, 226);
+
+  const lineSize = fitText(ctx, populationText, 470, 46, '800');
+  ctx.font = `800 ${lineSize}px Arial, Helvetica, sans-serif`;
+  ctx.lineWidth = 8;
+  ctx.strokeStyle = '#7b241b';
+  ctx.strokeText(populationText, textX, 306);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillText(populationText, textX, 306);
+}
+
+function drainDirection(graph) {
+  const drain = graph.segments[graph.drainSegmentId];
+  const direction = drain.end.clone().sub(drain.start);
+  direction.y = 0;
+  if (direction.lengthSq() < 0.0001) direction.set(0, 0, 1);
+  return direction.normalize();
+}
+
+export function createExitSign(graph) {
+  const createFace = (direction) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = CANVAS_WIDTH;
+    canvas.height = CANVAS_HEIGHT;
+    const ctx = canvas.getContext('2d');
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.colorSpace = THREE.SRGBColorSpace;
+    const material = new THREE.MeshBasicMaterial({
+      map: texture,
+      transparent: true,
+      side: THREE.FrontSide,
+      toneMapped: false,
+    });
+    return {
+      canvas,
+      ctx,
+      texture,
+      material,
+      mesh: new THREE.Mesh(new THREE.PlaneGeometry(SIGN_WIDTH, SIGN_HEIGHT), material),
+      direction,
+    };
+  };
+
+  const front = createFace(1);
+  const back = createFace(-1);
+  front.mesh.position.z = 0.025;
+  back.mesh.position.z = -0.025;
+  back.mesh.rotation.y = Math.PI;
+
+  front.mesh.renderOrder = 8;
+  back.mesh.renderOrder = 8;
+
+  const postMat = new THREE.MeshStandardMaterial({
+    color: 0x2a2523,
+    roughness: 0.55,
+    metalness: 0.4,
+  });
+  const postGeom = new THREE.CylinderGeometry(0.028, 0.04, 2.08, 10);
+
+  const group = new THREE.Group();
+  group.name = 'poopopulous-exit-sign';
+  group.add(front.mesh, back.mesh);
+
+  for (const x of [-1.28, 1.28]) {
+    const post = new THREE.Mesh(postGeom, postMat);
+    post.position.set(x, -1.44, -0.04);
+    post.castShadow = true;
+    post.receiveShadow = true;
+    group.add(post);
+  }
+
+  const glow = new THREE.PointLight(0xffb14f, 1.2, 4.5, 1.8);
+  glow.position.set(0.15, 0.08, 0.22);
+  group.add(glow);
+
+  const drain = graph.segments[graph.drainSegmentId];
+  const dir = drainDirection(graph);
+  const xAxis = dir;
+  const yAxis = new THREE.Vector3(0, 1, 0);
+  const zAxis = new THREE.Vector3().crossVectors(xAxis, yAxis).normalize();
+  const basis = new THREE.Matrix4().makeBasis(xAxis, yAxis, zAxis);
+  group.quaternion.setFromRotationMatrix(basis);
+  group.position.copy(drain.start)
+    .addScaledVector(dir, PIPE_TILE_SIZE * 1.08)
+    .addScaledVector(yAxis, SIGN_LIFT);
+
+  let lastDrained = -1;
+  let text = '';
+
+  function update(drainedParticles) {
+    const next = Math.floor(drainedParticles);
+    if (next === lastDrained) return;
+    lastDrained = next;
+    text = `Poopulation ${next.toLocaleString()}`;
+    for (const face of [front, back]) {
+      drawSignFace(face.ctx, next, face.direction);
+      face.texture.needsUpdate = true;
+    }
+  }
+
+  function dispose() {
+    for (const face of [front, back]) {
+      face.mesh.geometry.dispose();
+      face.material.dispose();
+      face.texture.dispose();
+    }
+    postGeom.dispose();
+    postMat.dispose();
+  }
+
+  update(0);
+
+  return {
+    group,
+    update,
+    dispose,
+    get text() { return text; },
+    get poopulation() { return lastDrained; },
+  };
+}

--- a/poopopulous-3000/src/level1/floaterPhysics.js
+++ b/poopopulous-3000/src/level1/floaterPhysics.js
@@ -1,0 +1,109 @@
+import * as THREE from 'three';
+import { loadPoopGeometry } from '../poopModel.js';
+import { FLOATER_SCALE, MAX_FLOATERS } from './constants.js';
+
+export async function createFloaterPhysics(scene, physics, simulation) {
+  const { RAPIER, world } = physics;
+  const { geom } = await loadPoopGeometry({ lod: 2, height: FLOATER_SCALE });
+  const mat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.66 });
+  const mesh = new THREE.InstancedMesh(geom, mat, MAX_FLOATERS);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+  scene.add(mesh);
+
+  const floaters = [];
+  const mat4 = new THREE.Matrix4();
+  const pos = new THREE.Vector3();
+  const quat = new THREE.Quaternion();
+  const scale = new THREE.Vector3(1, 1, 1);
+  let frame = 0;
+  let floaterClampCount = 0;
+
+  function spawnFloater() {
+    const sample = simulation.sampleSurface();
+    if (!sample) return;
+
+    const body = world.createRigidBody(
+      RAPIER.RigidBodyDesc.dynamic()
+        .setGravityScale(0)
+        .setTranslation(sample.position.x, sample.position.y, sample.position.z)
+        .setLinearDamping(1.8)
+        .setAngularDamping(4.5)
+        .setAngvel({
+          x: (Math.random() - 0.5) * 0.35,
+          y: (Math.random() - 0.5) * 0.35,
+          z: (Math.random() - 0.5) * 0.35,
+        })
+    );
+
+    world.createCollider(
+      RAPIER.ColliderDesc.ball(FLOATER_SCALE * 0.28)
+        .setFriction(0.6)
+        .setRestitution(0.08),
+      body
+    );
+
+    floaters.push({ body, sampleIndex: Math.floor(Math.random() * Math.max(1, simulation.count)) });
+  }
+
+  function update() {
+    frame++;
+    const desired = Math.min(MAX_FLOATERS, Math.floor(simulation.count / 165));
+    while (floaters.length < desired) spawnFloater();
+
+    mesh.count = floaters.length;
+    for (let i = floaters.length - 1; i >= 0; i--) {
+      const floater = floaters[i];
+      if (floater.sampleIndex >= simulation.count) floater.sampleIndex = Math.floor(Math.random() * Math.max(1, simulation.count));
+      const sample = simulation.sampleSurface(floater.sampleIndex);
+      if (!sample) continue;
+
+      const t = floater.body.translation();
+      pos.set(t.x, t.y, t.z);
+      const delta = sample.position.clone().sub(pos);
+
+      if (delta.length() > 1.2) {
+        floater.body.setTranslation(sample.position, true);
+        floater.body.setLinvel(sample.velocity, true);
+        floaterClampCount++;
+      } else {
+        const lin = floater.body.linvel();
+        const force = delta.multiplyScalar(12)
+          .add(sample.velocity.clone().multiplyScalar(2))
+          .add(new THREE.Vector3(-lin.x, -lin.y, -lin.z).multiplyScalar(3.5));
+        floater.body.addForce(force, true);
+      }
+
+      const ang = floater.body.angvel();
+      floater.body.setAngvel({ x: ang.x * 0.82, y: ang.y * 0.82, z: ang.z * 0.82 }, true);
+
+      if (frame % 180 === 0) {
+        floater.sampleIndex = Math.floor(Math.random() * Math.max(1, simulation.count));
+      }
+
+      const r = floater.body.rotation();
+      const p = floater.body.translation();
+      quat.set(r.x, r.y, r.z, r.w);
+      pos.set(p.x, p.y, p.z);
+      mat4.compose(pos, quat, scale);
+      mesh.setMatrixAt(i, mat4);
+    }
+
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  function dispose() {
+    for (const floater of floaters) world.removeRigidBody(floater.body);
+    floaters.length = 0;
+    scene.remove(mesh);
+    mat.dispose();
+  }
+
+  return {
+    update,
+    dispose,
+    get count() { return floaters.length; },
+    get floaterClampCount() { return floaterClampCount; },
+  };
+}

--- a/poopopulous-3000/src/level1/fluidRenderer.js
+++ b/poopopulous-3000/src/level1/fluidRenderer.js
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import { PARTICLE_RADIUS } from './constants.js';
+
+export function createFluidRenderer(scene, simulation) {
+  const geom = new THREE.SphereGeometry(PARTICLE_RADIUS * 1.35, 8, 6);
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0x4b2012,
+    roughness: 0.42,
+    metalness: 0.02,
+  });
+  const mesh = new THREE.InstancedMesh(geom, mat, simulation.maxParticles);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+  scene.add(mesh);
+
+  const mat4 = new THREE.Matrix4();
+  const pos = new THREE.Vector3();
+  const quat = new THREE.Quaternion();
+  const scale = new THREE.Vector3(1.45, 0.85, 1.45);
+
+  function update() {
+    const count = simulation.getRenderCount?.() ?? simulation.count;
+    mesh.count = count;
+    for (let i = 0; i < count; i++) {
+      if (simulation.getRenderPosition) simulation.getRenderPosition(i, pos);
+      else simulation.getPosition(i, pos);
+      mat4.compose(pos, quat, scale);
+      mesh.setMatrixAt(i, mat4);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+  }
+
+  function dispose() {
+    scene.remove(mesh);
+    geom.dispose();
+    mat.dispose();
+  }
+
+  return { update, dispose, mesh };
+}

--- a/poopopulous-3000/src/level1/fluidSimulation.js
+++ b/poopopulous-3000/src/level1/fluidSimulation.js
@@ -1,0 +1,716 @@
+import * as THREE from 'three';
+import {
+  MAX_FLUID_PARTICLES,
+  FLOW_EMIT_RATE,
+  PARTICLES_PER_PRE_POO,
+  PARTICLE_RADIUS,
+  PIPE_INNER_RADIUS,
+  SMOOTHING_RADIUS,
+  SPH_SUBSTEPS,
+  LEAK_SNAP_DISTANCE,
+} from './constants.js';
+import {
+  clampRadial,
+  nearestPipePoint,
+  particleWorldPosition,
+  randomLowerOffset,
+} from './pipeGeometry.js';
+
+const GRAVITY = new THREE.Vector3(0, -9.81, 0);
+const MAX_NEIGHBORS_PER_PARTICLE = 36;
+const OPEN_SEGMENT_CAPACITY_PER_UNIT = 92;
+const DEAD_END_CAPACITY_PER_UNIT = 48;
+const MIN_OPEN_SEGMENT_CAPACITY = 72;
+const MIN_DEAD_END_CAPACITY = 42;
+const NODE_PRESSURE_LENGTH = PIPE_INNER_RADIUS * 1.35;
+const TERMINAL_NODE_CAPACITY = 34;
+const CORNER_NODE_CAPACITY = 48;
+const JUNCTION_NODE_CAPACITY = 72;
+const MAX_CHUTE_PARTICLES = 140;
+const CHUTE_EMIT_HEIGHT = 1.02;
+const CHUTE_INJECT_HEIGHT = 0.48;
+const CHUTE_SPREAD = 0.1;
+const PRESSURE_RADIUS_SQ = SMOOTHING_RADIUS * SMOOTHING_RADIUS;
+const FLOW_DRAG_RADIUS = SMOOTHING_RADIUS * 1.16;
+const FLOW_DRAG_RADIUS_SQ = FLOW_DRAG_RADIUS * FLOW_DRAG_RADIUS;
+const FLOW_DRAG_HASH_RANGE = Math.ceil(FLOW_DRAG_RADIUS / SMOOTHING_RADIUS);
+const FLOW_FAST_BRAKE_COUPLING = 0.24;
+const FLOW_ENTRAINMENT_COUPLING = 0.82;
+const FLOW_ENTRAINMENT_PULL = 0.18;
+const FLOW_ENTRAINMENT_THRESHOLD = 0.45;
+const FLOW_ENTRAINMENT_MAX_SPEED = 2.6;
+const DRAIN_PATH_ACCELERATION = 0.64;
+
+function computeDrainDistances(graph) {
+  const distances = new Map();
+  const drainSegment = graph.segments[graph.drainSegmentId];
+  const drainNode = drainSegment?.b;
+  if (!drainNode) return distances;
+
+  distances.set(drainNode, 0);
+  const unsettled = new Set(graph.nodes.keys());
+
+  while (unsettled.size) {
+    let current = null;
+    let best = Infinity;
+
+    for (const id of unsettled) {
+      const distance = distances.get(id) ?? Infinity;
+      if (distance >= best) continue;
+      current = id;
+      best = distance;
+    }
+
+    if (!current) break;
+    unsettled.delete(current);
+
+    for (const segmentId of graph.nodeSegments.get(current) ?? []) {
+      const segment = graph.segments[segmentId];
+      const other = segment.a === current ? segment.b : segment.a;
+      if (!unsettled.has(other)) continue;
+      const nextDistance = best + segment.length;
+      if (nextDistance < (distances.get(other) ?? Infinity)) {
+        distances.set(other, nextDistance);
+      }
+    }
+  }
+
+  return distances;
+}
+
+function nodeDegree(graph, nodeId) {
+  return graph.nodeSegments.get(nodeId)?.length ?? 0;
+}
+
+function computeSegmentCapacities(graph) {
+  const capacities = new Float32Array(graph.segments.length);
+
+  for (const segment of graph.segments) {
+    if (segment.isDrain) {
+      capacities[segment.id] = Number.POSITIVE_INFINITY;
+      continue;
+    }
+
+    const terminal = nodeDegree(graph, segment.a) <= 1 || nodeDegree(graph, segment.b) <= 1;
+    capacities[segment.id] = terminal
+      ? Math.max(MIN_DEAD_END_CAPACITY, segment.length * DEAD_END_CAPACITY_PER_UNIT)
+      : Math.max(MIN_OPEN_SEGMENT_CAPACITY, segment.length * OPEN_SEGMENT_CAPACITY_PER_UNIT);
+  }
+
+  return capacities;
+}
+
+function computeNodeCapacities(graph, nodeIds) {
+  const capacities = new Float32Array(nodeIds.length);
+
+  for (let i = 0; i < nodeIds.length; i++) {
+    const degree = nodeDegree(graph, nodeIds[i]);
+    if (degree <= 1) capacities[i] = TERMINAL_NODE_CAPACITY;
+    else if (degree === 2) capacities[i] = CORNER_NODE_CAPACITY;
+    else capacities[i] = JUNCTION_NODE_CAPACITY;
+  }
+
+  return capacities;
+}
+
+function hashCoord(v) {
+  return Math.floor(v / SMOOTHING_RADIUS);
+}
+
+function hashKey(x, y, z) {
+  return `${x},${y},${z}`;
+}
+
+export class FluidSimulation {
+  constructor(graph, {
+    maxParticles = MAX_FLUID_PARTICLES,
+    emitRate = FLOW_EMIT_RATE,
+  } = {}) {
+    this.graph = graph;
+    this.maxParticles = maxParticles;
+    this.emitRate = emitRate;
+    this.count = 0;
+    this.emitAccumulator = 0;
+    this.drainedParticles = 0;
+    this.chuteCount = 0;
+
+    this.segmentIds = new Int32Array(maxParticles);
+    this.s = new Float32Array(maxParticles);
+    this.u = new Float32Array(maxParticles);
+    this.v = new Float32Array(maxParticles);
+    this.sVel = new Float32Array(maxParticles);
+    this.uVel = new Float32Array(maxParticles);
+    this.vVel = new Float32Array(maxParticles);
+    this.positions = new Float32Array(maxParticles * 3);
+    this.velocities = new Float32Array(maxParticles * 3);
+    this.chutePositions = new Float32Array(MAX_CHUTE_PARTICLES * 3);
+    this.chuteVelocities = new Float32Array(MAX_CHUTE_PARTICLES * 3);
+    this.segmentCounts = new Int32Array(graph.segments.length);
+    this.drainDistances = computeDrainDistances(graph);
+    this.segmentCapacities = computeSegmentCapacities(graph);
+    this.nodeIds = [...graph.nodes.keys()];
+    this.nodeIndexById = new Map(this.nodeIds.map((id, index) => [id, index]));
+    this.nodePressureCounts = new Int32Array(this.nodeIds.length);
+    this.nodeCapacities = computeNodeCapacities(graph, this.nodeIds);
+
+    this.hash = new Map();
+    this.metrics = {
+      outsidePipeCount: 0,
+      maxOutsideDistance: 0,
+      boundaryClampCount: 0,
+      connectorTransferCount: 0,
+      multiPathTransferCount: 0,
+      offPrimaryTransferCount: 0,
+      backpressureRejectCount: 0,
+      deadEndTransferCount: 0,
+      maxSegmentLoadRatio: 0,
+      fullSegmentCount: 0,
+      maxNodePressureRatio: 0,
+      fullNodeCount: 0,
+      avgNeighborCount: 0,
+      flowDragPairCount: 0,
+      flowDragImpulse: 0,
+      entrainmentImpulse: 0,
+    };
+  }
+
+  spawnAtEntry(n = 1) {
+    const { entrySegment, baseS, baseVel } = this._entrySpawnParams();
+
+    for (let i = 0; i < n && this.count < this.maxParticles; i++) {
+      const offset = randomLowerOffset();
+      this._addParticle(entrySegment.id, baseS + (Math.random() - 0.5) * 0.08, offset.u, offset.v, baseVel);
+    }
+  }
+
+  spawnFromChute(n = 1) {
+    const entry = this.graph.entryPosition;
+    for (
+      let i = 0;
+      i < n && this.chuteCount < MAX_CHUTE_PARTICLES && this.count + this.chuteCount < this.maxParticles;
+      i++
+    ) {
+      const index = this.chuteCount++;
+      const p = index * 3;
+      this.chutePositions[p] = entry.x + (Math.random() - 0.5) * CHUTE_SPREAD;
+      this.chutePositions[p + 1] = entry.y + CHUTE_EMIT_HEIGHT + Math.random() * 0.28;
+      this.chutePositions[p + 2] = entry.z + (Math.random() - 0.5) * CHUTE_SPREAD;
+      this.chuteVelocities[p] = (Math.random() - 0.5) * 0.08;
+      this.chuteVelocities[p + 1] = -1.35 - Math.random() * 0.65;
+      this.chuteVelocities[p + 2] = (Math.random() - 0.5) * 0.08;
+    }
+  }
+
+  _entrySpawnParams() {
+    const entrySegment = this.graph.segments[this.graph.entrySegmentId];
+    const fromStart = entrySegment.a === this.graph.entryNode;
+    const baseS = fromStart ? 0.12 : entrySegment.length - 0.12;
+    const baseVel = fromStart ? 0.3 : -0.3;
+    return { entrySegment, baseS, baseVel };
+  }
+
+  convertPoops(snapshots) {
+    for (const snapshot of snapshots) {
+      const nearest = nearestPipePoint(this.graph, snapshot.position);
+      const amount = Math.min(PARTICLES_PER_PRE_POO, this.maxParticles - this.count);
+      for (let i = 0; i < amount; i++) {
+        const offset = randomLowerOffset();
+        this._addParticle(
+          nearest.segment.id,
+          nearest.s + (Math.random() - 0.5) * 0.18,
+          nearest.u * 0.3 + offset.u * 0.7,
+          nearest.v * 0.3 + offset.v * 0.7,
+          0.15 + Math.random() * 0.4
+        );
+      }
+    }
+  }
+
+  update(dt, { emitting = false } = {}) {
+    if (emitting) {
+      this.emitAccumulator += this.emitRate * dt;
+      while (this.emitAccumulator >= 1 && this.count + this.chuteCount < this.maxParticles) {
+        this.spawnFromChute(1);
+        this.emitAccumulator -= 1;
+      }
+    } else {
+      this.emitAccumulator = Math.min(this.emitAccumulator, 1);
+    }
+
+    const subDt = Math.min(dt / SPH_SUBSTEPS, 1 / 45);
+    this._updateChute(Math.min(dt, 1 / 30));
+    this._updateWorldPositions();
+    this._pressurePass(Math.min(dt, 1 / 30));
+    for (let i = 0; i < SPH_SUBSTEPS; i++) {
+      this._updateSegmentCounts();
+      this._integrate(subDt);
+    }
+    this._updateWorldPositions();
+  }
+
+  getPosition(i, out = new THREE.Vector3()) {
+    return out.set(this.positions[i * 3], this.positions[i * 3 + 1], this.positions[i * 3 + 2]);
+  }
+
+  getRenderCount() {
+    return this.count + this.chuteCount;
+  }
+
+  getRenderPosition(i, out = new THREE.Vector3()) {
+    if (i < this.count) return this.getPosition(i, out);
+    const p = (i - this.count) * 3;
+    return out.set(this.chutePositions[p], this.chutePositions[p + 1], this.chutePositions[p + 2]);
+  }
+
+  getVelocity(i, out = new THREE.Vector3()) {
+    return out.set(this.velocities[i * 3], this.velocities[i * 3 + 1], this.velocities[i * 3 + 2]);
+  }
+
+  sampleSurface(index = Math.floor(Math.random() * Math.max(1, this.count))) {
+    if (!this.count) return null;
+    const i = Math.min(index, this.count - 1);
+    const segment = this.graph.segments[this.segmentIds[i]];
+    const pos = this.getPosition(i);
+    pos.addScaledVector(segment.top, PARTICLE_RADIUS * 2.4);
+    return {
+      position: pos,
+      velocity: this.getVelocity(i),
+      segment,
+    };
+  }
+
+  getMetrics() {
+    return {
+      activeParticles: this.count,
+      chuteParticles: this.chuteCount,
+      drainedParticles: this.drainedParticles,
+      outsidePipeCount: this.metrics.outsidePipeCount,
+      maxOutsideDistance: this.metrics.maxOutsideDistance,
+      boundaryClampCount: this.metrics.boundaryClampCount,
+      connectorTransferCount: this.metrics.connectorTransferCount,
+      multiPathTransferCount: this.metrics.multiPathTransferCount,
+      offPrimaryTransferCount: this.metrics.offPrimaryTransferCount,
+      backpressureRejectCount: this.metrics.backpressureRejectCount,
+      deadEndTransferCount: this.metrics.deadEndTransferCount,
+      maxSegmentLoadRatio: this.metrics.maxSegmentLoadRatio,
+      fullSegmentCount: this.metrics.fullSegmentCount,
+      maxNodePressureRatio: this.metrics.maxNodePressureRatio,
+      fullNodeCount: this.metrics.fullNodeCount,
+      avgNeighborCount: this.metrics.avgNeighborCount,
+      flowDragPairCount: this.metrics.flowDragPairCount,
+      flowDragImpulse: this.metrics.flowDragImpulse,
+      entrainmentImpulse: this.metrics.entrainmentImpulse,
+    };
+  }
+
+  _addParticle(segmentId, s, u, v, sVel) {
+    const i = this.count++;
+    this.segmentIds[i] = segmentId;
+    this.s[i] = s;
+    this.u[i] = u;
+    this.v[i] = v;
+    this.sVel[i] = sVel;
+    this.uVel[i] = (Math.random() - 0.5) * 0.08;
+    this.vVel[i] = (Math.random() - 0.5) * 0.08;
+  }
+
+  _removeParticle(i) {
+    const last = this.count - 1;
+    if (i !== last) {
+      this.segmentIds[i] = this.segmentIds[last];
+      this.s[i] = this.s[last];
+      this.u[i] = this.u[last];
+      this.v[i] = this.v[last];
+      this.sVel[i] = this.sVel[last];
+      this.uVel[i] = this.uVel[last];
+      this.vVel[i] = this.vVel[last];
+      this.positions.set(this.positions.subarray(last * 3, last * 3 + 3), i * 3);
+      this.velocities.set(this.velocities.subarray(last * 3, last * 3 + 3), i * 3);
+    }
+    this.count--;
+  }
+
+  _removeChuteParticle(i) {
+    const last = this.chuteCount - 1;
+    if (i !== last) {
+      this.chutePositions.set(this.chutePositions.subarray(last * 3, last * 3 + 3), i * 3);
+      this.chuteVelocities.set(this.chuteVelocities.subarray(last * 3, last * 3 + 3), i * 3);
+    }
+    this.chuteCount--;
+  }
+
+  _updateChute(dt) {
+    if (!this.chuteCount) return;
+
+    const entryY = this.graph.entryPosition.y + CHUTE_INJECT_HEIGHT;
+    const { entrySegment, baseS, baseVel } = this._entrySpawnParams();
+
+    for (let i = this.chuteCount - 1; i >= 0; i--) {
+      const p = i * 3;
+      this.chuteVelocities[p + 1] += GRAVITY.y * dt;
+      this.chuteVelocities[p] *= 0.985;
+      this.chuteVelocities[p + 2] *= 0.985;
+      this.chutePositions[p] += this.chuteVelocities[p] * dt;
+      this.chutePositions[p + 1] += this.chuteVelocities[p + 1] * dt;
+      this.chutePositions[p + 2] += this.chuteVelocities[p + 2] * dt;
+
+      if (this.chutePositions[p + 1] > entryY) continue;
+
+      if (this.count < this.maxParticles) {
+        const offset = randomLowerOffset();
+        this._addParticle(
+          entrySegment.id,
+          baseS + (Math.random() - 0.5) * 0.08,
+          offset.u * 0.55,
+          offset.v * 0.35,
+          baseVel + Math.random() * 0.25
+        );
+      }
+      this._removeChuteParticle(i);
+    }
+  }
+
+  _updateWorldPositions() {
+    this.metrics.outsidePipeCount = 0;
+    this.metrics.maxOutsideDistance = 0;
+
+    for (let i = 0; i < this.count; i++) {
+      const segment = this.graph.segments[this.segmentIds[i]];
+      const p = particleWorldPosition(segment, this.s[i], this.u[i], this.v[i]);
+      this.positions[i * 3] = p.x;
+      this.positions[i * 3 + 1] = p.y;
+      this.positions[i * 3 + 2] = p.z;
+
+      const velocity = segment.dir.clone().multiplyScalar(this.sVel[i])
+        .addScaledVector(segment.side, this.uVel[i])
+        .addScaledVector(segment.top, this.vVel[i]);
+      this.velocities[i * 3] = velocity.x;
+      this.velocities[i * 3 + 1] = velocity.y;
+      this.velocities[i * 3 + 2] = velocity.z;
+
+      const radial = Math.hypot(this.u[i], this.v[i]);
+      const outside = Math.max(0, radial - (PIPE_INNER_RADIUS - PARTICLE_RADIUS));
+      if (outside > 0) this.metrics.outsidePipeCount++;
+      this.metrics.maxOutsideDistance = Math.max(this.metrics.maxOutsideDistance, outside);
+    }
+  }
+
+  _buildHash() {
+    this.hash.clear();
+    for (let i = 0; i < this.count; i++) {
+      const x = hashCoord(this.positions[i * 3]);
+      const y = hashCoord(this.positions[i * 3 + 1]);
+      const z = hashCoord(this.positions[i * 3 + 2]);
+      const k = hashKey(x, y, z);
+      let bucket = this.hash.get(k);
+      if (!bucket) {
+        bucket = [];
+        this.hash.set(k, bucket);
+      }
+      bucket.push(i);
+    }
+  }
+
+  _updateSegmentCounts() {
+    this.segmentCounts.fill(0);
+    this.nodePressureCounts.fill(0);
+    for (let i = 0; i < this.count; i++) {
+      const segmentId = this.segmentIds[i];
+      const segment = this.graph.segments[segmentId];
+      this.segmentCounts[segmentId]++;
+
+      if (this.s[i] < NODE_PRESSURE_LENGTH) {
+        const index = this.nodeIndexById.get(segment.a);
+        if (index !== undefined) this.nodePressureCounts[index]++;
+      }
+      if (segment.length - this.s[i] < NODE_PRESSURE_LENGTH) {
+        const index = this.nodeIndexById.get(segment.b);
+        if (index !== undefined) this.nodePressureCounts[index]++;
+      }
+    }
+
+    this.metrics.maxSegmentLoadRatio = 0;
+    this.metrics.fullSegmentCount = 0;
+    for (let i = 0; i < this.segmentCounts.length; i++) {
+      const capacity = this.segmentCapacities[i];
+      if (!Number.isFinite(capacity)) continue;
+      const ratio = this.segmentCounts[i] / capacity;
+      this.metrics.maxSegmentLoadRatio = Math.max(this.metrics.maxSegmentLoadRatio, ratio);
+      if (ratio >= 1) this.metrics.fullSegmentCount++;
+    }
+
+    this.metrics.maxNodePressureRatio = 0;
+    this.metrics.fullNodeCount = 0;
+    for (let i = 0; i < this.nodePressureCounts.length; i++) {
+      const ratio = this.nodePressureCounts[i] / this.nodeCapacities[i];
+      this.metrics.maxNodePressureRatio = Math.max(this.metrics.maxNodePressureRatio, ratio);
+      if (ratio >= 1) this.metrics.fullNodeCount++;
+    }
+  }
+
+  _pressurePass(dt) {
+    this._buildHash();
+    let neighborTotal = 0;
+    this.metrics.flowDragPairCount = 0;
+    this.metrics.flowDragImpulse = 0;
+    this.metrics.entrainmentImpulse = 0;
+
+    for (let i = 0; i < this.count; i++) {
+      const px = this.positions[i * 3];
+      const py = this.positions[i * 3 + 1];
+      const pz = this.positions[i * 3 + 2];
+      const vx = this.velocities[i * 3];
+      const vy = this.velocities[i * 3 + 1];
+      const vz = this.velocities[i * 3 + 2];
+      const speed = Math.hypot(vx, vy, vz);
+      const cx = hashCoord(px);
+      const cy = hashCoord(py);
+      const cz = hashCoord(pz);
+      let neighbors = 0;
+
+      neighbors: for (let ox = -FLOW_DRAG_HASH_RANGE; ox <= FLOW_DRAG_HASH_RANGE; ox++) {
+        for (let oy = -FLOW_DRAG_HASH_RANGE; oy <= FLOW_DRAG_HASH_RANGE; oy++) {
+          for (let oz = -FLOW_DRAG_HASH_RANGE; oz <= FLOW_DRAG_HASH_RANGE; oz++) {
+            const bucket = this.hash.get(hashKey(cx + ox, cy + oy, cz + oz));
+            if (!bucket) continue;
+
+            for (const j of bucket) {
+              if (j === i) continue;
+              const dx = px - this.positions[j * 3];
+              const dy = py - this.positions[j * 3 + 1];
+              const dz = pz - this.positions[j * 3 + 2];
+              const d2 = dx * dx + dy * dy + dz * dz;
+              if (d2 <= 0.00001 || d2 > FLOW_DRAG_RADIUS_SQ) continue;
+
+              neighbors++;
+              const dist = Math.sqrt(d2);
+              const nx = dx / dist;
+              const ny = dy / dist;
+              const nz = dz / dist;
+              const segment = this.graph.segments[this.segmentIds[i]];
+
+              if (d2 <= PRESSURE_RADIUS_SQ) {
+                const push = (SMOOTHING_RADIUS - dist) / SMOOTHING_RADIUS;
+                const strength = push * push * 1.6;
+                this.sVel[i] += (nx * segment.dir.x + ny * segment.dir.y + nz * segment.dir.z) * strength * dt;
+                this.uVel[i] += (nx * segment.side.x + ny * segment.side.y + nz * segment.side.z) * strength * dt;
+                this.vVel[i] += (nx * segment.top.x + ny * segment.top.y + nz * segment.top.z) * strength * dt;
+              }
+
+              const dragKernel = (FLOW_DRAG_RADIUS - dist) / FLOW_DRAG_RADIUS;
+              const dragStrength = dragKernel * dragKernel;
+              const otherVx = this.velocities[j * 3];
+              const otherVy = this.velocities[j * 3 + 1];
+              const otherVz = this.velocities[j * 3 + 2];
+              const otherSpeed = Math.hypot(
+                otherVx,
+                otherVy,
+                otherVz
+              );
+              const speedGap = Math.abs(otherSpeed - speed);
+              if (speedGap <= FLOW_ENTRAINMENT_THRESHOLD) {
+                if (neighbors >= MAX_NEIGHBORS_PER_PARTICLE) break neighbors;
+                continue;
+              }
+
+              const coupling = otherSpeed > speed
+                ? FLOW_ENTRAINMENT_COUPLING
+                : FLOW_FAST_BRAKE_COUPLING;
+              const cappedGap = Math.min(speedGap - FLOW_ENTRAINMENT_THRESHOLD, FLOW_ENTRAINMENT_MAX_SPEED);
+              let ix = (otherVx - vx) * coupling * dragStrength * dt;
+              let iy = (otherVy - vy) * coupling * dragStrength * dt;
+              let iz = (otherVz - vz) * coupling * dragStrength * dt;
+
+              if (otherSpeed > speed) {
+                const pull = cappedGap * FLOW_ENTRAINMENT_PULL * dragStrength * dt;
+                ix -= nx * pull;
+                iy -= ny * pull;
+                iz -= nz * pull;
+                this.metrics.entrainmentImpulse += Math.hypot(ix, iy, iz);
+              }
+
+              this.sVel[i] += ix * segment.dir.x + iy * segment.dir.y + iz * segment.dir.z;
+              this.uVel[i] += ix * segment.side.x + iy * segment.side.y + iz * segment.side.z;
+              this.vVel[i] += ix * segment.top.x + iy * segment.top.y + iz * segment.top.z;
+              this.metrics.flowDragImpulse += Math.hypot(ix, iy, iz);
+              this.metrics.flowDragPairCount++;
+
+              if (neighbors >= MAX_NEIGHBORS_PER_PARTICLE) break neighbors;
+            }
+          }
+        }
+      }
+
+      neighborTotal += neighbors;
+    }
+
+    this.metrics.avgNeighborCount = this.count ? neighborTotal / this.count : 0;
+  }
+
+  _integrate(dt) {
+    for (let i = this.count - 1; i >= 0; i--) {
+      const segment = this.graph.segments[this.segmentIds[i]];
+      const alongGravity = GRAVITY.dot(segment.dir) * 1.08;
+      const drainPath = this._drainPathAcceleration(segment);
+      const topGravity = GRAVITY.dot(segment.top) * 0.12;
+
+      this.sVel[i] += (alongGravity + drainPath) * dt;
+      this.vVel[i] += topGravity * dt;
+
+      this.sVel[i] *= 0.997;
+      this.uVel[i] *= 0.94;
+      this.vVel[i] *= 0.94;
+
+      this.sVel[i] = THREE.MathUtils.clamp(this.sVel[i], -7.0, 7.0);
+      this.uVel[i] = THREE.MathUtils.clamp(this.uVel[i], -1.2, 1.2);
+      this.vVel[i] = THREE.MathUtils.clamp(this.vVel[i], -1.2, 1.2);
+
+      this.s[i] += this.sVel[i] * dt;
+      this.u[i] += this.uVel[i] * dt;
+      this.v[i] += this.vVel[i] * dt;
+
+      const clamped = clampRadial(this.u[i], this.v[i]);
+      if (clamped.clamped) {
+        const len = Math.max(Math.hypot(this.u[i], this.v[i]), 0.0001);
+        const nx = this.u[i] / len;
+        const ny = this.v[i] / len;
+        const outward = this.uVel[i] * nx + this.vVel[i] * ny;
+        if (outward > 0) {
+          this.uVel[i] -= outward * nx * 1.25;
+          this.vVel[i] -= outward * ny * 1.25;
+        }
+        this.u[i] = clamped.u;
+        this.v[i] = clamped.v;
+        this.metrics.boundaryClampCount++;
+      }
+
+      if (!this._handleSegmentCrossing(i)) continue;
+
+      const p = this.getPosition(i);
+      const nearest = nearestPipePoint(this.graph, p);
+      if (nearest.outsideDistance > LEAK_SNAP_DISTANCE) {
+        this.segmentIds[i] = nearest.segment.id;
+        this.s[i] = nearest.s;
+        this.u[i] = nearest.u;
+        this.v[i] = nearest.v;
+        this.metrics.boundaryClampCount++;
+      }
+    }
+  }
+
+  _drainPathAcceleration(segment) {
+    if (segment.isDrain) return 0;
+    const aDistance = this.drainDistances.get(segment.a) ?? Infinity;
+    const bDistance = this.drainDistances.get(segment.b) ?? Infinity;
+    if (!Number.isFinite(aDistance) || !Number.isFinite(bDistance)) return 0;
+
+    const normalizedGradient = THREE.MathUtils.clamp((aDistance - bDistance) / segment.length, -1, 1);
+    return normalizedGradient * DRAIN_PATH_ACCELERATION;
+  }
+
+  _handleSegmentCrossing(i) {
+    let guard = 0;
+    while (guard++ < 4) {
+      const segment = this.graph.segments[this.segmentIds[i]];
+      if (this.s[i] >= 0 && this.s[i] <= segment.length) return true;
+
+      if (segment.isDrain && this.s[i] > segment.length) {
+        this._removeParticle(i);
+        this.drainedParticles++;
+        return false;
+      }
+
+      const atStart = this.s[i] < 0;
+      const node = atStart ? segment.a : segment.b;
+      const overflow = atStart ? -this.s[i] : this.s[i] - segment.length;
+      const candidates = (this.graph.nodeSegments.get(node) ?? []).filter((id) => id !== segment.id);
+
+      if (!candidates.length) {
+        this.s[i] = atStart ? 0.02 : segment.length - 0.02;
+        this.sVel[i] *= -0.35;
+        return true;
+      }
+
+      let totalWeight = 0;
+      const options = [];
+      const primaryNext = this.graph.primaryNextSegmentByNode?.get(node);
+      for (const id of candidates) {
+        const candidate = this.graph.segments[id];
+        const leavesFromStart = candidate.a === node;
+        const sign = leavesFromStart ? 1 : -1;
+        const outgoing = candidate.dir.clone().multiplyScalar(sign);
+        const downhill = GRAVITY.dot(outgoing);
+        const incoming = segment.dir.clone().multiplyScalar(this.sVel[i]);
+        const incomingLength = incoming.length();
+        const alignment = incomingLength > 0.001 ? outgoing.dot(incoming.multiplyScalar(1 / incomingLength)) : 0;
+        const load = this.segmentCounts[id] ?? 0;
+        const targetNode = leavesFromStart ? candidate.b : candidate.a;
+        const currentDrainDistance = this.drainDistances.get(node) ?? Infinity;
+        const nextDrainDistance = this.drainDistances.get(targetNode) ?? Infinity;
+        const drainProgress = Number.isFinite(currentDrainDistance) && Number.isFinite(nextDrainDistance)
+          ? Math.max(0, currentDrainDistance - nextDrainDistance)
+          : 0;
+        const capacity = this.segmentCapacities[id] ?? MIN_OPEN_SEGMENT_CAPACITY;
+        const fillRatio = Number.isFinite(capacity) ? load / capacity : 0;
+        const targetDegree = nodeDegree(this.graph, targetNode);
+        const entersDeadEnd = !candidate.isDrain && targetDegree <= 1;
+        const targetNodeIndex = this.nodeIndexById.get(targetNode);
+        const targetNodeFill = targetNodeIndex === undefined || candidate.isDrain
+          ? 0
+          : this.nodePressureCounts[targetNodeIndex] / this.nodeCapacities[targetNodeIndex];
+        const terminalIsFull = entersDeadEnd && (fillRatio >= 1 || targetNodeFill >= 1);
+        if (terminalIsFull) {
+          this.metrics.backpressureRejectCount++;
+          continue;
+        }
+
+        const fillExcess = Math.max(0, fillRatio - (entersDeadEnd ? 0.55 : 0.82));
+        const nodeExcess = Math.max(0, targetNodeFill - (entersDeadEnd ? 0.58 : 0.85));
+        const capacityGate = candidate.isDrain ? 1 : 1 / (1 + fillExcess * fillExcess * 6);
+        const nodeGate = candidate.isDrain ? 1 : 1 / (1 + nodeExcess * nodeExcess * 8);
+        const deadEndGate = entersDeadEnd ? nodeGate / (1 + fillExcess * fillExcess * 8) : Math.max(0.35, nodeGate);
+        const downhillWeight = Math.max(0, downhill) * 1.65;
+        const flatBranchWeight = downhill > -0.08 ? 0.7 : 0.08;
+        const inertiaWeight = Math.max(0, alignment) * 1.1;
+        const uphillPenalty = downhill < -0.08 ? 0.12 : 1;
+        const drainBonus = candidate.isDrain ? 16 : 0;
+        const drainPathWeight = drainProgress * 2.4;
+        const loadRelief = capacityGate * deadEndGate;
+        const weight = (flatBranchWeight + downhillWeight + inertiaWeight + drainPathWeight + drainBonus)
+          * uphillPenalty
+          * loadRelief;
+        if (weight < 0.001) {
+          this.metrics.backpressureRejectCount++;
+          continue;
+        }
+        totalWeight += weight;
+        options.push({ candidate, sign, leavesFromStart, weight, primary: id === primaryNext, entersDeadEnd });
+      }
+
+      if (!options.length || totalWeight <= 0) {
+        this.s[i] = atStart ? 0.02 : segment.length - 0.02;
+        this.sVel[i] *= -0.25;
+        return true;
+      }
+
+      let best = options[options.length - 1];
+      let roll = Math.random() * totalWeight;
+      for (const option of options) {
+        roll -= option.weight;
+        if (roll > 0) continue;
+        best = option;
+        break;
+      }
+
+      this.segmentIds[i] = best.candidate.id;
+      this.s[i] = best.leavesFromStart ? overflow : best.candidate.length - overflow;
+      this.sVel[i] = Math.max(Math.abs(this.sVel[i]) * 0.92, 0.25) * best.sign;
+      this.metrics.connectorTransferCount++;
+      if (candidates.length > 1) this.metrics.multiPathTransferCount++;
+      if (!best.primary) this.metrics.offPrimaryTransferCount++;
+      if (best.entersDeadEnd) this.metrics.deadEndTransferCount++;
+    }
+
+    return true;
+  }
+}

--- a/poopopulous-3000/src/level1/pipeColliders.js
+++ b/poopopulous-3000/src/level1/pipeColliders.js
@@ -1,0 +1,72 @@
+import * as THREE from 'three';
+import { PIPE_INNER_RADIUS, PIPE_WALL_THICKNESS } from './constants.js';
+
+const WORLD_UP = new THREE.Vector3(0, 1, 0);
+
+function colliderTop(segment) {
+  const top = new THREE.Vector3().crossVectors(segment.side, segment.dir).normalize();
+  if (top.dot(WORLD_UP) < 0) top.multiplyScalar(-1);
+  return top;
+}
+
+function segmentRotation(segment) {
+  const top = colliderTop(segment);
+  const basis = new THREE.Matrix4().makeBasis(segment.dir, top, segment.side);
+  return new THREE.Quaternion().setFromRotationMatrix(basis);
+}
+
+function addBox(world, RAPIER, segment, center, halfExtents, rotation, colliders) {
+  const collider = world.createCollider(
+    RAPIER.ColliderDesc.cuboid(halfExtents.x, halfExtents.y, halfExtents.z)
+      .setTranslation(center.x, center.y, center.z)
+      .setRotation(rotation)
+      .setFriction(0.95)
+      .setRestitution(0.05)
+  );
+  colliders.push(collider);
+}
+
+export function createPipeColliders(physics, graph) {
+  const { RAPIER, world } = physics;
+  const colliders = [];
+  const floorThickness = PIPE_WALL_THICKNESS * 0.75;
+  const sideThickness = PIPE_WALL_THICKNESS;
+  const wallHeight = PIPE_INNER_RADIUS * 0.9;
+
+  for (const segment of graph.segments) {
+    const rotation = segmentRotation(segment);
+    const top = colliderTop(segment);
+    const midpoint = segment.start.clone().add(segment.end).multiplyScalar(0.5);
+    const halfLength = segment.length / 2 + PIPE_INNER_RADIUS * 0.18;
+
+    addBox(
+      world,
+      RAPIER,
+      segment,
+      midpoint.clone().addScaledVector(top, -PIPE_INNER_RADIUS),
+      new THREE.Vector3(halfLength, floorThickness, PIPE_INNER_RADIUS * 0.92),
+      rotation,
+      colliders
+    );
+
+    for (const side of [-1, 1]) {
+      addBox(
+        world,
+        RAPIER,
+        segment,
+        midpoint.clone().addScaledVector(segment.side, side * PIPE_INNER_RADIUS * 0.94)
+          .addScaledVector(top, -PIPE_INNER_RADIUS * 0.25),
+        new THREE.Vector3(halfLength, wallHeight, sideThickness),
+        rotation,
+        colliders
+      );
+    }
+  }
+
+  return {
+    dispose() {
+      for (const collider of colliders) world.removeCollider(collider, false);
+      colliders.length = 0;
+    },
+  };
+}

--- a/poopopulous-3000/src/level1/pipeGeometry.js
+++ b/poopopulous-3000/src/level1/pipeGeometry.js
@@ -1,0 +1,445 @@
+import * as THREE from 'three';
+import {
+  PIPE_INNER_RADIUS,
+  PIPE_RADIUS,
+  PIPE_TILE_SIZE,
+  PIPE_WALL_THICKNESS,
+  PARTICLE_RADIUS,
+  BOUNDARY_SKIN,
+  SLOPE_DROP_PER_ROW,
+} from './constants.js';
+
+const WORLD_UP = new THREE.Vector3(0, 1, 0);
+const ELBOW_ARC_STEPS = 14;
+const ELBOW_VERTICAL_STEPS = 12;
+const ELBOW_OVERLAP_ANGLE = 0.045;
+const SADDLE_CUT_DEPTH = 0.78;
+const ROW_SLOPE_PER_WORLD_Z = -SLOPE_DROP_PER_ROW / PIPE_TILE_SIZE;
+const SLOPE_UP = new THREE.Vector3(0, 1, -ROW_SLOPE_PER_WORLD_Z).normalize();
+
+export function preparePipeFrames(graph) {
+  for (const segment of graph.segments) {
+    const side = new THREE.Vector3().crossVectors(segment.dir, SLOPE_UP);
+    if (side.lengthSq() < 0.0001) side.set(1, 0, 0);
+    side.normalize();
+
+    segment.side = side;
+    segment.top = SLOPE_UP.clone();
+    segment.bottom = SLOPE_UP.clone().multiplyScalar(-1);
+  }
+
+  return graph;
+}
+
+function lowerHalfTubeGeometry(segment, radius, radialSteps = 18, {
+  startCutSides = [],
+  endCutSides = [],
+} = {}) {
+  const positions = [];
+  const normals = [];
+  const indices = [];
+  const arcStart = Math.PI;
+  const arcEnd = Math.PI * 2;
+  const hasCuts = Boolean(startCutSides.length || endCutSides.length);
+  const axialSteps = hasCuts ? 6 : 1;
+
+  for (let ring = 0; ring <= axialSteps; ring++) {
+    const t = ring / axialSteps;
+    for (let i = 0; i <= radialSteps; i++) {
+      const theta = arcStart + (arcEnd - arcStart) * (i / radialSteps);
+      const startBack = saddleCutback(theta, startCutSides, radius);
+      const endBack = saddleCutback(theta, endCutSides, radius);
+      const usableLength = Math.max(0.03, segment.length - startBack - endBack);
+      const base = segment.start.clone().addScaledVector(segment.dir, startBack + usableLength * t);
+      const radial = segment.side.clone().multiplyScalar(Math.cos(theta))
+        .add(segment.top.clone().multiplyScalar(Math.sin(theta)));
+      const p = base.clone().add(radial.clone().multiplyScalar(radius));
+      positions.push(p.x, p.y, p.z);
+      normals.push(radial.x, radial.y, radial.z);
+    }
+  }
+
+  for (let ring = 0; ring < axialSteps; ring++) {
+    const row = radialSteps + 1;
+    for (let i = 0; i < radialSteps; i++) {
+      const a = ring * row + i;
+      const b = a + 1;
+      const c = (ring + 1) * row + i + 1;
+      const d = (ring + 1) * row + i;
+      indices.push(a, d, b, b, d, c);
+    }
+  }
+
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geom.setIndex(indices);
+  return geom;
+}
+
+function saddleCutback(theta, sides, radius) {
+  let amount = 0;
+  for (const side of sides) {
+    amount = Math.max(amount, Math.max(0, side * Math.cos(theta)));
+  }
+  return amount * radius * SADDLE_CUT_DEPTH;
+}
+
+function connectedDirections(graph, id) {
+  const node = graph.nodes.get(id);
+  return (graph.nodeSegments.get(id) ?? []).map((segmentId) => {
+    const segment = graph.segments[segmentId];
+    const otherId = segment.a === id ? segment.b : segment.a;
+    const other = graph.nodes.get(otherId);
+
+    return {
+      x: Math.sign(other.c - node.c),
+      z: Math.sign(other.r - node.r),
+      segment,
+    };
+  });
+}
+
+function isStraightThrough(dirs) {
+  return dirs.length === 2 && dirs[0].x === -dirs[1].x && dirs[0].z === -dirs[1].z;
+}
+
+export function classifyPipeNode(graph, id) {
+  const dirs = connectedDirections(graph, id);
+  const degree = dirs.length;
+  let type = 'dead-end';
+
+  if (degree === 2) type = isStraightThrough(dirs) ? 'straight' : 'corner';
+  else if (degree === 3) type = 'tee';
+  else if (degree === 4) type = 'cross';
+  else if (degree > 4) type = 'overfull';
+
+  return { type, degree, dirs };
+}
+
+function needsFitting(type) {
+  return type === 'corner';
+}
+
+function cutSidesForSegmentEndpoint(graph, nodeId, segment) {
+  const { type, dirs } = classifyPipeNode(graph, nodeId);
+  if (type === 'dead-end' || type === 'straight') return [];
+
+  const current = dirs.find((dir) => dir.segment.id === segment.id);
+  if (!current) return [];
+
+  const currentVector = new THREE.Vector3(current.x, 0, current.z);
+  const sides = new Set();
+
+  for (const other of dirs) {
+    if (other.segment.id === segment.id) continue;
+
+    const otherVector = new THREE.Vector3(other.x, 0, other.z);
+    if (currentVector.dot(otherVector) < -0.5) continue;
+
+    const sideDot = otherVector.dot(segment.side);
+    if (Math.abs(sideDot) > 0.25) sides.add(sideDot >= 0 ? 1 : -1);
+  }
+
+  return [...sides];
+}
+
+function normalizeAngle(angle) {
+  let a = angle;
+  while (a <= -Math.PI) a += Math.PI * 2;
+  while (a > Math.PI) a -= Math.PI * 2;
+  return a;
+}
+
+function cornerLowerHemisphereGeometry(node, dirs, radius) {
+  const positions = [];
+  const normals = [];
+  const indices = [];
+  const a0 = Math.atan2(dirs[0].z, dirs[0].x) + Math.PI;
+  const a1 = Math.atan2(dirs[1].z, dirs[1].x) + Math.PI;
+  let delta = normalizeAngle(a1 - a0);
+
+  if (Math.abs(delta) > Math.PI / 2 + 0.001) {
+    delta = delta > 0 ? delta - Math.PI * 2 : delta + Math.PI * 2;
+  }
+
+  const direction = Math.sign(delta) || 1;
+  const startAngle = a0 - direction * ELBOW_OVERLAP_ANGLE;
+  const arcDelta = delta + direction * ELBOW_OVERLAP_ANGLE * 2;
+
+  for (let arc = 0; arc <= ELBOW_ARC_STEPS; arc++) {
+    const angle = startAngle + arcDelta * (arc / ELBOW_ARC_STEPS);
+    const horizontal = new THREE.Vector3(
+      Math.cos(angle),
+      ROW_SLOPE_PER_WORLD_Z * Math.sin(angle),
+      Math.sin(angle)
+    ).normalize();
+
+    for (let v = 0; v <= ELBOW_VERTICAL_STEPS; v++) {
+      const t = (Math.PI / 2) * (v / ELBOW_VERTICAL_STEPS);
+      const radial = horizontal.clone().multiplyScalar(Math.cos(t))
+        .addScaledVector(SLOPE_UP, -Math.sin(t));
+      const p = node.position.clone().addScaledVector(radial, radius);
+      positions.push(p.x, p.y, p.z);
+      normals.push(radial.x, radial.y, radial.z);
+    }
+  }
+
+  const row = ELBOW_VERTICAL_STEPS + 1;
+  for (let arc = 0; arc < ELBOW_ARC_STEPS; arc++) {
+    for (let v = 0; v < ELBOW_VERTICAL_STEPS; v++) {
+      const a = arc * row + v;
+      const b = a + 1;
+      const c = (arc + 1) * row + v + 1;
+      const d = (arc + 1) * row + v;
+      indices.push(a, d, b, b, d, c);
+    }
+  }
+
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geom.setIndex(indices);
+  geom.computeVertexNormals();
+  return geom;
+}
+
+function deadEndCapGeometry(segment, nodeId, radius, radialSteps = 20) {
+  const positions = [];
+  const normals = [];
+  const indices = [];
+  const atStart = segment.a === nodeId;
+  const center = atStart ? segment.start : segment.end;
+  const capUp = segment.top.clone();
+  const normal = segment.dir.clone().multiplyScalar(atStart ? -1 : 1);
+  const capCenter = center.clone().addScaledVector(normal, 0.004);
+
+  positions.push(capCenter.x, capCenter.y, capCenter.z);
+  normals.push(normal.x, normal.y, normal.z);
+
+  for (let i = 0; i <= radialSteps; i++) {
+    const theta = Math.PI + Math.PI * (i / radialSteps);
+    const radial = segment.side.clone().multiplyScalar(Math.cos(theta))
+      .add(capUp.clone().multiplyScalar(Math.sin(theta)));
+    const p = capCenter.clone().addScaledVector(radial, radius);
+    positions.push(p.x, p.y, p.z);
+    normals.push(normal.x, normal.y, normal.z);
+  }
+
+  for (let i = 1; i <= radialSteps; i++) {
+    if (atStart) indices.push(0, i, i + 1);
+    else indices.push(0, i + 1, i);
+  }
+
+  const geom = new THREE.BufferGeometry();
+  geom.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geom.setAttribute('normal', new THREE.Float32BufferAttribute(normals, 3));
+  geom.setIndex(indices);
+  return geom;
+}
+
+function shouldCapDeadEnd(graph, nodeId, segment) {
+  if (segment.isDrain || nodeId === graph.entryNode) return false;
+  if (nodeId === graph.segments[graph.drainSegmentId]?.b) return false;
+  return (graph.nodeSegments.get(nodeId)?.length ?? 0) <= 1;
+}
+
+function createSpawnPipeVisual(entryPosition, pipeMat, innerMat) {
+  const group = new THREE.Group();
+  group.name = 'level1-spawn-pipe';
+
+  const bodyRadius = PIPE_RADIUS * 0.94;
+  const lipRadius = PIPE_RADIUS * 1.16;
+  const bodyHeight = 2.65;
+  const lipHeight = 0.24;
+  const bottomY = entryPosition.y + 1.08;
+  const radialSegments = 40;
+
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(bodyRadius, bodyRadius, bodyHeight, radialSegments, 1, true),
+    pipeMat
+  );
+  body.position.set(entryPosition.x, bottomY + bodyHeight / 2, entryPosition.z);
+  body.castShadow = true;
+  body.receiveShadow = true;
+  group.add(body);
+
+  const lip = new THREE.Mesh(
+    new THREE.CylinderGeometry(lipRadius, lipRadius, lipHeight, radialSegments, 1, true),
+    pipeMat
+  );
+  lip.position.set(entryPosition.x, bottomY + lipHeight / 2, entryPosition.z);
+  lip.castShadow = true;
+  lip.receiveShadow = true;
+  group.add(lip);
+
+  const rim = new THREE.Mesh(
+    new THREE.TorusGeometry(lipRadius, PIPE_WALL_THICKNESS * 0.62, 10, radialSegments),
+    pipeMat
+  );
+  rim.rotation.x = Math.PI / 2;
+  rim.position.set(entryPosition.x, bottomY, entryPosition.z);
+  rim.castShadow = true;
+  rim.receiveShadow = true;
+  group.add(rim);
+
+  const inner = new THREE.Mesh(
+    new THREE.CylinderGeometry(PIPE_INNER_RADIUS * 0.9, PIPE_INNER_RADIUS * 0.9, 0.72, radialSegments, 1, true),
+    innerMat
+  );
+  inner.position.set(entryPosition.x, bottomY + 0.34, entryPosition.z);
+  inner.receiveShadow = true;
+  group.add(inner);
+
+  return group;
+}
+
+export function getPipeFittingStats(graph) {
+  const stats = {
+    pipeNodes: graph.nodes.size,
+    junctionCorners: 0,
+    junctionTees: 0,
+    junctionCrosses: 0,
+    junctionStraights: 0,
+    junctionDeadEnds: 0,
+    junctionOverfull: 0,
+    renderedFittings: 0,
+  };
+
+  for (const id of graph.nodes.keys()) {
+    const { type } = classifyPipeNode(graph, id);
+    if (type === 'corner') stats.junctionCorners++;
+    else if (type === 'tee') stats.junctionTees++;
+    else if (type === 'cross') stats.junctionCrosses++;
+    else if (type === 'straight') stats.junctionStraights++;
+    else if (type === 'dead-end') stats.junctionDeadEnds++;
+    else if (type === 'overfull') stats.junctionOverfull++;
+
+    if (needsFitting(type)) stats.renderedFittings++;
+  }
+
+  return stats;
+}
+
+export function createPipeVisuals(graph) {
+  preparePipeFrames(graph);
+
+  const group = new THREE.Group();
+  group.name = 'level1-pipes';
+
+  const pipeMat = new THREE.MeshStandardMaterial({
+    color: 0x18a91d,
+    roughness: 0.62,
+    metalness: 0.05,
+    side: THREE.DoubleSide,
+  });
+  const connectorMat = new THREE.MeshStandardMaterial({
+    color: 0x18a91d,
+    roughness: 0.62,
+    metalness: 0.05,
+    side: THREE.DoubleSide,
+  });
+  const innerMat = new THREE.MeshStandardMaterial({
+    color: 0x0b5e18,
+    roughness: 0.9,
+    side: THREE.DoubleSide,
+  });
+
+  for (const segment of graph.segments) {
+    const cuts = {
+      startCutSides: cutSidesForSegmentEndpoint(graph, segment.a, segment),
+      endCutSides: cutSidesForSegmentEndpoint(graph, segment.b, segment),
+    };
+    const mesh = new THREE.Mesh(lowerHalfTubeGeometry(segment, PIPE_RADIUS, 18, cuts), pipeMat);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    group.add(mesh);
+
+    const inner = new THREE.Mesh(lowerHalfTubeGeometry(segment, PIPE_INNER_RADIUS, 14, cuts), innerMat);
+    inner.receiveShadow = true;
+    group.add(inner);
+
+    for (const nodeId of [segment.a, segment.b]) {
+      if (!shouldCapDeadEnd(graph, nodeId, segment)) continue;
+      const cap = new THREE.Mesh(deadEndCapGeometry(segment, nodeId, PIPE_RADIUS), pipeMat);
+      cap.castShadow = true;
+      cap.receiveShadow = true;
+      group.add(cap);
+    }
+  }
+
+  for (const [id, node] of graph.nodes.entries()) {
+    const { type, dirs } = classifyPipeNode(graph, id);
+    if (!needsFitting(type)) continue;
+
+    const mesh = new THREE.Mesh(cornerLowerHemisphereGeometry(node, dirs, PIPE_RADIUS), connectorMat);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    group.add(mesh);
+
+    const inner = new THREE.Mesh(cornerLowerHemisphereGeometry(node, dirs, PIPE_INNER_RADIUS), innerMat);
+    inner.receiveShadow = true;
+    group.add(inner);
+  }
+
+  group.add(createSpawnPipeVisual(graph.entryPosition, pipeMat, innerMat));
+
+  return group;
+}
+
+export function particleWorldPosition(segment, s, u, v, out = new THREE.Vector3()) {
+  return out.copy(segment.start)
+    .addScaledVector(segment.dir, s)
+    .addScaledVector(segment.side, u)
+    .addScaledVector(segment.top, v);
+}
+
+export function clampRadial(u, v) {
+  const maxRadius = PIPE_INNER_RADIUS - PARTICLE_RADIUS - BOUNDARY_SKIN;
+  const dist = Math.hypot(u, v);
+  if (dist <= maxRadius) return { u, v, clamped: false };
+  const f = maxRadius / Math.max(dist, 0.0001);
+  return { u: u * f, v: v * f, clamped: true };
+}
+
+export function randomLowerOffset(rng = Math.random) {
+  const radius = (PIPE_INNER_RADIUS - PARTICLE_RADIUS - BOUNDARY_SKIN) * Math.sqrt(rng());
+  const theta = Math.PI + Math.PI * rng();
+  return {
+    u: Math.cos(theta) * radius * 0.85,
+    v: Math.sin(theta) * radius * 0.85,
+  };
+}
+
+export function nearestPipePoint(graph, point) {
+  let best = null;
+  const tmp = new THREE.Vector3();
+  const pointVec = new THREE.Vector3(point.x, point.y, point.z);
+
+  for (const segment of graph.segments) {
+    const rel = tmp.copy(pointVec).sub(segment.start);
+    const s = THREE.MathUtils.clamp(rel.dot(segment.dir), 0, segment.length);
+    const center = segment.start.clone().addScaledVector(segment.dir, s);
+    const radial = pointVec.clone().sub(center);
+    const u = radial.dot(segment.side);
+    const v = radial.dot(segment.top);
+    const radialDistance = Math.hypot(u, v);
+    const outside = Math.max(0, radialDistance - (PIPE_INNER_RADIUS - PARTICLE_RADIUS));
+    const score = outside + center.distanceTo(point) * 0.001;
+
+    if (!best || score < best.score) {
+      const clamped = clampRadial(u, v);
+      best = {
+        score,
+        segment,
+        s,
+        u: clamped.u,
+        v: clamped.v,
+        outsideDistance: outside,
+        position: particleWorldPosition(segment, s, clamped.u, clamped.v),
+      };
+    }
+  }
+
+  return best;
+}

--- a/poopopulous-3000/src/level1/pipeGraph.js
+++ b/poopopulous-3000/src/level1/pipeGraph.js
@@ -1,0 +1,336 @@
+import * as THREE from 'three';
+import {
+  LEVEL_COLS,
+  LEVEL_ROWS,
+  PIPE_TILE_SIZE,
+  SLOPE_DROP_PER_ROW,
+} from './constants.js';
+
+export const DIRS = {
+  N: { bit: 1, dc: 0, dr: -1, opposite: 'S' },
+  E: { bit: 2, dc: 1, dr: 0, opposite: 'W' },
+  S: { bit: 4, dc: 0, dr: 1, opposite: 'N' },
+  W: { bit: 8, dc: -1, dr: 0, opposite: 'E' },
+};
+
+function hashSeed(seed) {
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function createRng(seed) {
+  let state = hashSeed(seed) || 1;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return ((state >>> 0) / 4294967296);
+  };
+}
+
+export function createPipeSeed() {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID === 'function') return randomUUID.call(globalThis.crypto);
+
+  const bytes = new Uint32Array(4);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 0xffffffff);
+  }
+
+  return [...bytes].map((value) => value.toString(16).padStart(8, '0')).join('-');
+}
+
+function clamp(v, min, max) {
+  return Math.max(min, Math.min(max, v));
+}
+
+function key(c, r) {
+  return `${c},${r}`;
+}
+
+function edgeKey(a, b) {
+  return [key(a.c, a.r), key(b.c, b.r)].sort().join('|');
+}
+
+function fromKey(k) {
+  const [c, r] = k.split(',').map(Number);
+  return { c, r };
+}
+
+function nodeId(c, r) {
+  return `${c}:${r}`;
+}
+
+function nodePosition(c, r) {
+  return new THREE.Vector3(
+    (c - (LEVEL_COLS - 1) / 2) * PIPE_TILE_SIZE,
+    1.15 - r * SLOPE_DROP_PER_ROW,
+    (r - (LEVEL_ROWS - 1) / 2) * PIPE_TILE_SIZE
+  );
+}
+
+function addEdge(cells, a, b) {
+  const dc = b.c - a.c;
+  const dr = b.r - a.r;
+  const dir = Object.entries(DIRS).find(([, d]) => d.dc === dc && d.dr === dr)?.[0];
+  if (!dir) return false;
+
+  cells.set(key(a.c, a.r), (cells.get(key(a.c, a.r)) ?? 0) | DIRS[dir].bit);
+  cells.set(key(b.c, b.r), (cells.get(key(b.c, b.r)) ?? 0) | DIRS[DIRS[dir].opposite].bit);
+  return true;
+}
+
+function bitCount(mask) {
+  let n = 0;
+  for (const dir of Object.values(DIRS)) if (mask & dir.bit) n++;
+  return n;
+}
+
+function hasEdge(cells, a, b) {
+  const dc = b.c - a.c;
+  const dr = b.r - a.r;
+  const dir = Object.entries(DIRS).find(([, d]) => d.dc === dc && d.dr === dr)?.[0];
+  return Boolean(dir && (cells.get(key(a.c, a.r)) ?? 0) & DIRS[dir].bit);
+}
+
+function tryAddEdge(cells, a, b, { allowMerge = false } = {}) {
+  if (!inBounds(b.c, b.r)) return false;
+  if (hasEdge(cells, a, b)) return true;
+
+  const aMask = cells.get(key(a.c, a.r)) ?? 0;
+  const bMask = cells.get(key(b.c, b.r)) ?? 0;
+  const bOccupied = cells.has(key(b.c, b.r));
+
+  // Treat occupied pipe cells as solid unless this branch is explicitly
+  // merging into the chosen endpoint. This avoids visual overpasses.
+  if (bOccupied && !allowMerge) return false;
+  if (bitCount(aMask) >= 4 || bitCount(bMask) >= 4) return false;
+
+  return addEdge(cells, a, b);
+}
+
+function inBounds(c, r) {
+  return c >= 0 && c < LEVEL_COLS && r >= 0 && r < LEVEL_ROWS;
+}
+
+function randomDir(rng, biasDown = 0.45) {
+  const roll = rng();
+  if (roll < biasDown) return 'S';
+  if (roll < biasDown + 0.25) return 'E';
+  if (roll < biasDown + 0.5) return 'W';
+  return 'N';
+}
+
+function shuffledDirs(primary, rng) {
+  const dirs = ['S', 'E', 'W', 'N'].filter((d) => d !== primary);
+  for (let i = dirs.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
+  }
+  return [primary, ...dirs];
+}
+
+function shuffledAllDirs(rng) {
+  const dirs = ['S', 'E', 'W', 'N'];
+  for (let i = dirs.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [dirs[i], dirs[j]] = [dirs[j], dirs[i]];
+  }
+  return dirs;
+}
+
+function ensureFourWayJunction(cells, route, rng) {
+  const candidates = [...route]
+    .filter((cell) => cell.c > 0 && cell.c < LEVEL_COLS - 1 && cell.r > 0 && cell.r < LEVEL_ROWS - 1);
+
+  for (let i = candidates.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
+  }
+
+  for (const base of candidates) {
+    let guard = 0;
+    while (bitCount(cells.get(key(base.c, base.r)) ?? 0) < 4 && guard++ < 4) {
+      let added = false;
+      const mask = cells.get(key(base.c, base.r)) ?? 0;
+
+      for (const name of shuffledAllDirs(rng)) {
+        if (mask & DIRS[name].bit) continue;
+        const next = { c: base.c + DIRS[name].dc, r: base.r + DIRS[name].dr };
+        if (!tryAddEdge(cells, base, next, { allowMerge: true })) continue;
+        added = true;
+        break;
+      }
+
+      if (!added) break;
+    }
+
+    if (bitCount(cells.get(key(base.c, base.r)) ?? 0) === 4) return true;
+  }
+
+  return false;
+}
+
+export function generatePipeGraph(seed = createPipeSeed()) {
+  const rng = createRng(seed);
+  const cells = new Map();
+  const route = [];
+  const mainEdges = new Set();
+
+  let c = 2 + Math.floor(rng() * (LEVEL_COLS - 4));
+  let r = 0;
+  const entry = { c, r };
+  cells.set(key(c, r), 0);
+  route.push({ c, r });
+
+  while (r < LEVEL_ROWS - 1) {
+    const down = { c, r: r + 1 };
+    const prev = { c, r };
+    addEdge(cells, prev, down);
+    mainEdges.add(edgeKey(prev, down));
+    r = down.r;
+    route.push({ c, r });
+
+    const target = clamp(c + Math.floor(rng() * 3) - 1, 1, LEVEL_COLS - 2);
+    while (c !== target) {
+      const next = { c: c + Math.sign(target - c), r };
+      const previous = { c, r };
+      addEdge(cells, previous, next);
+      mainEdges.add(edgeKey(previous, next));
+      c = next.c;
+      route.push({ c, r });
+    }
+
+  }
+
+  const exit = { c, r };
+  const branchCount = 18 + Math.floor(rng() * 11);
+  for (let i = 0; i < branchCount; i++) {
+    const start = route[Math.floor(rng() * route.length)];
+    let bc = start.c;
+    let br = start.r;
+    const length = 3 + Math.floor(rng() * 6);
+    const mergeTarget = rng() < 0.4 ? route[Math.floor(rng() * route.length)] : null;
+
+    for (let j = 0; j < length; j++) {
+      let dir = randomDir(rng, br < LEVEL_ROWS - 2 ? 0.35 : 0.1);
+      if (mergeTarget && j > length / 2) {
+        if (Math.abs(mergeTarget.c - bc) > Math.abs(mergeTarget.r - br)) {
+          dir = mergeTarget.c > bc ? 'E' : 'W';
+        } else {
+          dir = mergeTarget.r > br ? 'S' : 'N';
+        }
+      }
+
+      for (const candidate of shuffledDirs(dir, rng)) {
+        const next = { c: bc + DIRS[candidate].dc, r: br + DIRS[candidate].dr };
+        const allowMerge = Boolean(mergeTarget && next.c === mergeTarget.c && next.r === mergeTarget.r);
+        if (!tryAddEdge(cells, { c: bc, r: br }, next, { allowMerge })) continue;
+        bc = next.c;
+        br = next.r;
+        break;
+      }
+    }
+  }
+
+  ensureFourWayJunction(cells, route, rng);
+
+  const nodes = new Map();
+  const nodeSegments = new Map();
+  const segmentByEdge = new Map();
+  const segments = [];
+  const seenEdges = new Set();
+
+  function ensureNode(cn, rn) {
+    const id = nodeId(cn, rn);
+    if (!nodes.has(id)) nodes.set(id, { id, c: cn, r: rn, position: nodePosition(cn, rn) });
+    if (!nodeSegments.has(id)) nodeSegments.set(id, []);
+    return id;
+  }
+
+  for (const [cellKey, mask] of cells.entries()) {
+    const cell = fromKey(cellKey);
+    ensureNode(cell.c, cell.r);
+    for (const [name, dir] of Object.entries(DIRS)) {
+      if (!(mask & dir.bit)) continue;
+      const other = { c: cell.c + dir.dc, r: cell.r + dir.dr };
+      const segmentEdgeKey = edgeKey(cell, other);
+      if (seenEdges.has(segmentEdgeKey) || !inBounds(other.c, other.r)) continue;
+      seenEdges.add(segmentEdgeKey);
+
+      const [from, to] = (
+        other.r < cell.r || (other.r === cell.r && other.c < cell.c)
+      )
+        ? [other, cell]
+        : [cell, other];
+      const a = ensureNode(from.c, from.r);
+      const b = ensureNode(to.c, to.r);
+      const start = nodes.get(a).position.clone();
+      const end = nodes.get(b).position.clone();
+      const id = segments.length;
+      const segment = { id, a, b, start, end, isDrain: false, isMain: mainEdges.has(segmentEdgeKey) };
+      segments.push(segment);
+      segmentByEdge.set(segmentEdgeKey, id);
+      nodeSegments.get(a).push(id);
+      nodeSegments.get(b).push(id);
+    }
+  }
+
+  const exitNode = ensureNode(exit.c, exit.r);
+  const drainStart = nodes.get(exitNode).position.clone();
+  const drainEnd = nodePosition(exit.c, LEVEL_ROWS + 1);
+  const drainNode = `drain:${exit.c}`;
+  nodes.set(drainNode, { id: drainNode, c: exit.c, r: LEVEL_ROWS + 1, position: drainEnd });
+  nodeSegments.set(drainNode, []);
+  const drainSegment = { id: segments.length, a: exitNode, b: drainNode, start: drainStart, end: drainEnd, isDrain: true, isMain: true };
+  segments.push(drainSegment);
+  segmentByEdge.set(edgeKey(exit, { c: exit.c, r: LEVEL_ROWS + 1 }), drainSegment.id);
+  nodeSegments.get(exitNode).push(drainSegment.id);
+  nodeSegments.get(drainNode).push(drainSegment.id);
+
+  for (const segment of segments) {
+    segment.vector = segment.end.clone().sub(segment.start);
+    segment.length = segment.vector.length();
+    segment.dir = segment.vector.clone().normalize();
+  }
+
+  const entryNode = ensureNode(entry.c, entry.r);
+  const primaryNextSegmentByNode = new Map();
+  for (let i = 0; i < route.length - 1; i++) {
+    const a = route[i];
+    const b = route[i + 1];
+    const segmentId = segmentByEdge.get(edgeKey(a, b));
+    if (segmentId !== undefined) primaryNextSegmentByNode.set(nodeId(a.c, a.r), segmentId);
+  }
+  primaryNextSegmentByNode.set(exitNode, drainSegment.id);
+
+  const entrySegmentId = (nodeSegments.get(entryNode) ?? [])
+    .filter((id) => !segments[id].isDrain)
+    .sort((a, b) => {
+      const sa = segments[a].a === entryNode ? segments[a].end.y - segments[a].start.y : segments[a].start.y - segments[a].end.y;
+      const sb = segments[b].a === entryNode ? segments[b].end.y - segments[b].start.y : segments[b].start.y - segments[b].end.y;
+      return sa - sb;
+    })[0] ?? 0;
+  const entryPosition = nodes.get(entryNode).position.clone();
+
+  return {
+    seed,
+    cells,
+    nodes,
+    nodeSegments,
+    segments,
+    entry,
+    exit,
+    entryNode,
+    entrySegmentId,
+    entryPosition,
+    drainSegmentId: drainSegment.id,
+    primaryNextSegmentByNode,
+  };
+}

--- a/poopopulous-3000/src/main.js
+++ b/poopopulous-3000/src/main.js
@@ -1,11 +1,11 @@
 import { createWorld } from './world.js';
 import { createPhysics } from './physics.js';
-import { createPoops } from './poops.js';
 import { createAudio } from './audio.js';
 import { createKaraoke } from './karaoke.js';
+import { createSplashMode } from './modes/splashMode.js';
+import { createLevel1Mode } from './modes/level1Mode.js';
 
-const NORMAL_INTERVAL = 950;   // ms between poos, same cadence as 2.0
-const UNLEASHED_INTERVAL = 16; // v2's zero-interval unleash: one turd per frame
+const PHYSICS_DT = 1 / 60;
 
 const world = createWorld(document.getElementById('app'));
 const physics = await createPhysics();
@@ -13,28 +13,92 @@ const audio = createAudio();
 const karaoke = createKaraoke();
 
 const counterEl = document.getElementById('counter');
-let unleashed = false;
-
-const poops = await createPoops(world.scene, physics, {
-  onSpawn: () => audio.plop({ storm: unleashed }),
-  onCount: (n) => { counterEl.textContent = `💩 × ${n.toLocaleString()}`; },
-});
-
-// --- UI ---
+const startLevelBtn = document.getElementById('startLevelBtn');
+const backBtn = document.getElementById('backBtn');
+const regenBtn = document.getElementById('regenBtn');
 const unleashBtn = document.getElementById('unleashBtn');
-unleashBtn.addEventListener('click', () => {
-  unleashed = !unleashed;
+const muteBtn = document.getElementById('muteBtn');
+const karaokeBtn = document.getElementById('karaokeBtn');
+
+let activeMode = null;
+let activeModeName = 'splash';
+let accumulator = 0;
+let lastTime = performance.now();
+
+function setCounter(text) {
+  counterEl.textContent = text;
+}
+
+function setButtonHidden(button, hidden) {
+  button.classList.toggle('hidden', hidden);
+}
+
+function syncUnleashButton() {
+  const unleashed = activeMode?.unleashed ?? false;
   unleashBtn.classList.toggle('active', unleashed);
   unleashBtn.textContent = unleashed ? '🧘 Calm the Poos!' : '🌊 Unleash the Poos!';
+}
+
+function syncHud() {
+  const inLevel = activeModeName === 'level1';
+  setButtonHidden(startLevelBtn, inLevel);
+  setButtonHidden(backBtn, !inLevel);
+  setButtonHidden(regenBtn, !inLevel);
+  syncUnleashButton();
+}
+
+async function switchMode(next) {
+  activeMode?.dispose();
+  activeMode = null;
+
+  async function startSplashMode() {
+    activeModeName = 'splash';
+    activeMode = await createSplashMode({
+      world,
+      physics,
+      audio,
+      setCounter,
+      onUnleashChange: syncUnleashButton,
+    });
+  }
+
+  try {
+    if (next === 'level1') {
+      activeModeName = 'level1';
+      activeMode = await createLevel1Mode({
+        world,
+        physics,
+        audio,
+        setCounter,
+        onUnleashChange: syncUnleashButton,
+      });
+    } else {
+      await startSplashMode();
+    }
+  } catch (error) {
+    console.error(`Failed to start ${next} mode`, error);
+    activeMode?.dispose?.();
+    activeMode = null;
+    await startSplashMode();
+  }
+
+  syncHud();
+}
+
+startLevelBtn.addEventListener('click', () => { switchMode('level1'); });
+backBtn.addEventListener('click', () => { switchMode('splash'); });
+regenBtn.addEventListener('click', () => { switchMode('level1'); });
+
+unleashBtn.addEventListener('click', () => {
+  activeMode?.setUnleashed?.(!activeMode.unleashed);
+  syncUnleashButton();
 });
 
-const muteBtn = document.getElementById('muteBtn');
 muteBtn.addEventListener('click', () => {
   audio.setMuted(!audio.muted);
   muteBtn.textContent = audio.muted ? '🔇 Sound Off' : '🔊 Sound On';
 });
 
-const karaokeBtn = document.getElementById('karaokeBtn');
 karaokeBtn.addEventListener('click', async () => {
   if (karaoke.playing) {
     karaoke.stop();
@@ -45,22 +109,10 @@ karaokeBtn.addEventListener('click', async () => {
   }
 });
 
-// --- Main loop ---
-const PHYSICS_DT = 1 / 60;
-let accumulator = 0;
-let lastTime = performance.now();
-let lastSpawn = 0;
-
 function loop(now) {
   requestAnimationFrame(loop);
   const dt = Math.min((now - lastTime) / 1000, 0.1);
   lastTime = now;
-
-  const interval = unleashed ? UNLEASHED_INTERVAL : NORMAL_INTERVAL;
-  if (now - lastSpawn >= interval) {
-    poops.spawn();
-    lastSpawn = now;
-  }
 
   accumulator += dt;
   while (accumulator >= PHYSICS_DT) {
@@ -68,13 +120,22 @@ function loop(now) {
     accumulator -= PHYSICS_DT;
   }
 
-  poops.update();
+  activeMode?.update({ now, dt });
   karaoke.update();
   world.controls.update();
   world.renderer.render(world.scene, world.camera);
 }
 
+await switchMode('splash');
 requestAnimationFrame(loop);
 
-// Handle for automated tests and console tinkering
-window.__game = { world, physics, poops, karaoke, audio };
+// Handle for automated tests and console tinkering.
+window.__game = {
+  get mode() { return activeModeName; },
+  world,
+  physics,
+  karaoke,
+  audio,
+  get splash() { return activeModeName === 'splash' ? activeMode : null; },
+  get level1() { return activeModeName === 'level1' ? activeMode : null; },
+};

--- a/poopopulous-3000/src/modes/level1Mode.js
+++ b/poopopulous-3000/src/modes/level1Mode.js
@@ -1,0 +1,165 @@
+import * as THREE from 'three';
+import { createPoops } from '../poops.js';
+import { createPipeVisuals, getPipeFittingStats } from '../level1/pipeGeometry.js';
+import { FluidSimulation } from '../level1/fluidSimulation.js';
+import { createFluidRenderer } from '../level1/fluidRenderer.js';
+import { createFloaterPhysics } from '../level1/floaterPhysics.js';
+import { createPipeSeed, generatePipeGraph } from '../level1/pipeGraph.js';
+import { createPipeColliders } from '../level1/pipeColliders.js';
+import { createExitSign } from '../level1/exitSign.js';
+import {
+  FLOATER_SCALE,
+  MAX_PRE_UNLEASH_POOS,
+  PRE_UNLEASH_INTERVAL,
+} from '../level1/constants.js';
+
+export async function createLevel1Mode({
+  world,
+  physics,
+  audio,
+  setCounter,
+  onUnleashChange,
+  seed = createPipeSeed(),
+}) {
+  world.setSplashVisible(false);
+  world.setCameraHome({ position: [14, 13, 15], target: [0, 0.2, 0.5], zoom: 1.25 });
+
+  const group = new THREE.Group();
+  group.name = 'level-1';
+  world.scene.add(group);
+
+  const graph = generatePipeGraph(seed);
+  const pipeGroup = createPipeVisuals(graph);
+  group.add(pipeGroup);
+  const exitSign = createExitSign(graph);
+  group.add(exitSign.group);
+  const pipeColliders = createPipeColliders(physics, graph);
+
+  const fluid = new FluidSimulation(graph);
+  const fluidRenderer = createFluidRenderer(group, fluid);
+  const floaters = await createFloaterPhysics(group, physics, fluid);
+
+  let unleashed = false;
+  let prePoops = await createPoops(group, physics, {
+    maxPoops: MAX_PRE_UNLEASH_POOS,
+    maxDynamic: MAX_PRE_UNLEASH_POOS,
+    settleSeconds: 15,
+    poopHeight: FLOATER_SCALE,
+    spawnCenter: {
+      x: graph.entryPosition.x,
+      y: graph.entryPosition.y + 1.35,
+      z: graph.entryPosition.z,
+    },
+    spawnSpread: 0.12,
+    onSpawn: () => audio.plop({ storm: false }),
+    onCount: (n) => { setCounter(`💩 × ${n.toLocaleString()}`); },
+  });
+
+  let lastPreSpawn = 0;
+  let lastStormSound = 0;
+  let lastNow = performance.now();
+  let fpsEstimate = 60;
+  const graphStats = (() => {
+    const degrees = [...graph.nodeSegments.values()].map((segments) => segments.length);
+    return {
+      pipeSegments: graph.segments.length,
+      maxNodeDegree: Math.max(...degrees),
+      overfullNodes: degrees.filter((degree) => degree > 4).length,
+      ...getPipeFittingStats(graph),
+    };
+  })();
+
+  setCounter('💩 × 0');
+
+  function setUnleashed(value) {
+    if (value === unleashed) return;
+    unleashed = value;
+    onUnleashChange?.(unleashed);
+
+    if (unleashed && prePoops) {
+      const snapshots = prePoops.getSnapshots();
+      fluid.convertPoops(snapshots);
+      if (!snapshots.length) fluid.spawnAtEntry(80);
+      prePoops.dispose();
+      prePoops = null;
+    }
+  }
+
+  function updateCounter() {
+    if (!unleashed) {
+      setCounter(`💩 × ${(prePoops?.total ?? 0).toLocaleString()}`);
+      return;
+    }
+
+    setCounter(`💩 fluid × ${fluid.count.toLocaleString()} · floaters × ${floaters.count}`);
+  }
+
+  function update({ now, dt }) {
+    fpsEstimate = fpsEstimate * 0.92 + (1 / Math.max(dt, 0.001)) * 0.08;
+
+    if (!unleashed && prePoops) {
+      if (now - lastPreSpawn >= PRE_UNLEASH_INTERVAL && prePoops.count < MAX_PRE_UNLEASH_POOS) {
+        prePoops.spawn();
+        lastPreSpawn = now;
+      }
+      prePoops.update();
+    }
+
+    fluid.update(dt, { emitting: unleashed });
+    exitSign.update(fluid.drainedParticles);
+    if (unleashed && now - lastStormSound > 75) {
+      audio.plop({ storm: true });
+      lastStormSound = now;
+    }
+
+    fluidRenderer.update();
+    floaters.update();
+    updateCounter();
+    lastNow = now;
+  }
+
+  function getMetrics() {
+    return {
+      ...fluid.getMetrics(),
+      activeFloaters: floaters.count,
+      prePooCount: prePoops?.count ?? 0,
+      floaterClampCount: floaters.floaterClampCount,
+      fpsEstimate,
+      seed,
+      unleashed,
+      lastNow,
+      exitSignText: exitSign.text,
+      exitSignPoopulation: exitSign.poopulation,
+      ...graphStats,
+    };
+  }
+
+  function dispose() {
+    prePoops?.dispose();
+    exitSign.dispose();
+    fluidRenderer.dispose();
+    floaters.dispose();
+    pipeColliders.dispose();
+    world.scene.remove(group);
+    group.traverse((obj) => {
+      if (obj.geometry && !obj.isInstancedMesh) obj.geometry.dispose?.();
+      if (obj.material && !obj.isInstancedMesh) {
+        if (Array.isArray(obj.material)) obj.material.forEach((m) => m.dispose?.());
+        else obj.material.dispose?.();
+      }
+    });
+  }
+
+  return {
+    name: 'level1',
+    seed,
+    update,
+    dispose,
+    setUnleashed,
+    getMetrics,
+    regenerate: () => {},
+    get unleashed() { return unleashed; },
+    get graph() { return graph; },
+    get fluid() { return fluid; },
+  };
+}

--- a/poopopulous-3000/src/modes/splashMode.js
+++ b/poopopulous-3000/src/modes/splashMode.js
@@ -1,0 +1,47 @@
+import { createPoops } from '../poops.js';
+
+const NORMAL_INTERVAL = 950;   // ms between poos, same cadence as 2.0
+const UNLEASHED_INTERVAL = 16; // v2's zero-interval unleash: one turd per frame
+
+export async function createSplashMode({ world, physics, audio, setCounter, onUnleashChange }) {
+  world.setSplashVisible(true);
+  world.setCameraHome({ position: [20, 20, 20], target: [0, 0, 0], zoom: 1 });
+
+  let unleashed = false;
+  let lastSpawn = 0;
+
+  const poops = await createPoops(world.splashGroup, physics, {
+    onSpawn: () => audio.plop({ storm: unleashed }),
+    onCount: (n) => { setCounter(`💩 × ${n.toLocaleString()}`); },
+  });
+
+  setCounter('💩 × 0');
+
+  function setUnleashed(value) {
+    unleashed = value;
+    onUnleashChange?.(unleashed);
+  }
+
+  function update({ now }) {
+    const interval = unleashed ? UNLEASHED_INTERVAL : NORMAL_INTERVAL;
+    if (now - lastSpawn >= interval) {
+      poops.spawn();
+      lastSpawn = now;
+    }
+
+    poops.update();
+  }
+
+  function dispose() {
+    poops.dispose();
+  }
+
+  return {
+    name: 'splash',
+    update,
+    dispose,
+    setUnleashed,
+    get unleashed() { return unleashed; },
+    get poops() { return poops; },
+  };
+}

--- a/poopopulous-3000/src/poopModel.js
+++ b/poopopulous-3000/src/poopModel.js
@@ -1,0 +1,67 @@
+import * as THREE from 'three';
+import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
+import { MTLLoader } from 'three/addons/loaders/MTLLoader.js';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+const cache = new Map();
+
+// Bake material colors into vertex colors so the same geometry can be used by
+// instanced meshes without creating one draw call per material.
+function bakeColors(mesh) {
+  const out = [];
+  const geom = mesh.geometry.index ? mesh.geometry.toNonIndexed() : mesh.geometry;
+  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  const groups = geom.groups?.length
+    ? geom.groups
+    : [{ start: 0, count: geom.attributes.position.count, materialIndex: 0 }];
+
+  for (const g of groups) {
+    const sub = new THREE.BufferGeometry();
+    for (const name of ['position', 'normal']) {
+      const attr = geom.attributes[name];
+      if (!attr) continue;
+      const arr = attr.array.slice(g.start * attr.itemSize, (g.start + g.count) * attr.itemSize);
+      sub.setAttribute(name, new THREE.BufferAttribute(arr, attr.itemSize));
+    }
+
+    const color = mats[g.materialIndex]?.color ?? new THREE.Color(0xffffff);
+    const colors = new Float32Array(g.count * 3);
+    for (let i = 0; i < g.count; i++) colors.set([color.r, color.g, color.b], i * 3);
+    sub.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    out.push(sub);
+  }
+
+  return out;
+}
+
+export async function loadPoopGeometry({ lod = 1, height = 0.9 } = {}) {
+  const key = `${lod}:${height}`;
+  if (cache.has(key)) return cache.get(key);
+
+  const name = `LOD${lod}emoji_poop`;
+  const mtl = await new MTLLoader().setPath('assets/models/').loadAsync(`${name}.mtl`);
+  mtl.preload();
+
+  const obj = await new OBJLoader()
+    .setMaterials(mtl)
+    .setPath('assets/models/')
+    .loadAsync(`${name}.obj`);
+
+  const parts = [];
+  obj.traverse((child) => { if (child.isMesh) parts.push(...bakeColors(child)); });
+  const geom = mergeGeometries(parts);
+
+  // Normalize: center on origin, rest base on y=0, scale to requested height.
+  geom.computeBoundingBox();
+  const bb = geom.boundingBox;
+  const size = new THREE.Vector3();
+  bb.getSize(size);
+  const scale = height / size.y;
+  geom.translate(-(bb.min.x + bb.max.x) / 2, -bb.min.y, -(bb.min.z + bb.max.z) / 2);
+  geom.scale(scale, scale, scale);
+  geom.computeBoundingBox();
+
+  const result = { geom, size: size.multiplyScalar(scale) };
+  cache.set(key, result);
+  return result;
+}

--- a/poopopulous-3000/src/poops.js
+++ b/poopopulous-3000/src/poops.js
@@ -1,7 +1,5 @@
 import * as THREE from 'three';
-import { OBJLoader } from 'three/addons/loaders/OBJLoader.js';
-import { MTLLoader } from 'three/addons/loaders/MTLLoader.js';
-import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { loadPoopGeometry } from './poopModel.js';
 
 const MAX_POOPS = 4000;     // instanced mesh capacity
 const MAX_DYNAMIC = 350;    // active physics bodies before we start freezing the oldest
@@ -9,63 +7,23 @@ const SETTLE_SECONDS = 8;   // v2's DisablePhysicsAfterTime, reborn
 const POOP_HEIGHT = 0.9;    // world-space size of one poop
 const SPAWN_HEIGHT = 9;
 
-// Bake material colors into vertex colors so the whole model can be drawn
-// as a single InstancedMesh (one draw call for thousands of poops).
-function bakeColors(mesh) {
-  const out = [];
-  const geom = mesh.geometry.index ? mesh.geometry.toNonIndexed() : mesh.geometry;
-  const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
-  const groups = geom.groups?.length
-    ? geom.groups
-    : [{ start: 0, count: geom.attributes.position.count, materialIndex: 0 }];
-
-  for (const g of groups) {
-    const sub = new THREE.BufferGeometry();
-    for (const name of ['position', 'normal']) {
-      const attr = geom.attributes[name];
-      if (!attr) continue;
-      const arr = attr.array.slice(g.start * attr.itemSize, (g.start + g.count) * attr.itemSize);
-      sub.setAttribute(name, new THREE.BufferAttribute(arr, attr.itemSize));
-    }
-    const color = mats[g.materialIndex]?.color ?? new THREE.Color(0xffffff);
-    const colors = new Float32Array(g.count * 3);
-    for (let i = 0; i < g.count; i++) colors.set([color.r, color.g, color.b], i * 3);
-    sub.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    out.push(sub);
-  }
-  return out;
-}
-
-async function loadPoopGeometry() {
-  const mtl = await new MTLLoader().setPath('assets/models/').loadAsync('LOD1emoji_poop.mtl');
-  mtl.preload();
-  const obj = await new OBJLoader().setMaterials(mtl).setPath('assets/models/').loadAsync('LOD1emoji_poop.obj');
-
-  const parts = [];
-  obj.traverse((child) => { if (child.isMesh) parts.push(...bakeColors(child)); });
-  const geom = mergeGeometries(parts);
-
-  // Normalize: center on origin, rest base on y=0, scale to POOP_HEIGHT
-  geom.computeBoundingBox();
-  const bb = geom.boundingBox;
-  const size = new THREE.Vector3();
-  bb.getSize(size);
-  const scale = POOP_HEIGHT / size.y;
-  geom.translate(-(bb.min.x + bb.max.x) / 2, -bb.min.y, -(bb.min.z + bb.max.z) / 2);
-  geom.scale(scale, scale, scale);
-  geom.computeBoundingBox();
-
-  return { geom, size: size.multiplyScalar(scale) };
-}
-
-export async function createPoops(scene, physics, { onSpawn, onCount } = {}) {
+export async function createPoops(scene, physics, {
+  onSpawn,
+  onCount,
+  maxPoops = MAX_POOPS,
+  maxDynamic = MAX_DYNAMIC,
+  settleSeconds = SETTLE_SECONDS,
+  spawnCenter = { x: 0, y: SPAWN_HEIGHT, z: 0 },
+  spawnSpread = 0.8,
+  poopHeight = POOP_HEIGHT,
+} = {}) {
   const { RAPIER, world } = physics;
-  const { geom, size } = await loadPoopGeometry();
+  const { geom, size } = await loadPoopGeometry({ height: poopHeight });
 
   const mesh = new THREE.InstancedMesh(
     geom,
     new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.65 }),
-    MAX_POOPS
+    maxPoops
   );
   mesh.count = 0;
   mesh.castShadow = true;
@@ -85,12 +43,16 @@ export async function createPoops(scene, physics, { onSpawn, onCount } = {}) {
   const coneHalfHeight = size.y / 2;
   const coneRadius = Math.max(size.x, size.z) / 2 * 0.85;
 
-  function spawn() {
-    if (mesh.count >= MAX_POOPS) return;
+  function spawn({ center = spawnCenter, spread = spawnSpread } = {}) {
+    if (mesh.count >= maxPoops) return;
 
     const body = world.createRigidBody(
       RAPIER.RigidBodyDesc.dynamic()
-        .setTranslation((Math.random() - 0.5) * 0.8, SPAWN_HEIGHT, (Math.random() - 0.5) * 0.8)
+        .setTranslation(
+          center.x + (Math.random() - 0.5) * spread,
+          center.y,
+          center.z + (Math.random() - 0.5) * spread
+        )
         .setRotation(new THREE.Quaternion().setFromEuler(
           new THREE.Euler(0, Math.random() * Math.PI * 2, (Math.random() - 0.5) * 0.5)
         ))
@@ -150,19 +112,43 @@ export async function createPoops(scene, physics, { onSpawn, onCount } = {}) {
       mat4.compose(pos, quat, one);
       mesh.setMatrixAt(p.slot, mat4);
 
-      if (p.body.isSleeping() || now - p.born > SETTLE_SECONDS * 1000) {
+      if (p.body.isSleeping() || now - p.born > settleSeconds * 1000) {
         freeze(p);
         dynamic.splice(i, 1);
       }
     }
 
     // Perf valve: under heavy unleashing, retire the oldest movers first
-    while (dynamic.length > MAX_DYNAMIC) {
+    while (dynamic.length > maxDynamic) {
       freeze(dynamic.shift());
     }
 
     mesh.instanceMatrix.needsUpdate = true;
   }
 
-  return { spawn, update, get total() { return totalSpawned; } };
+  function getSnapshots() {
+    return poops.filter(Boolean).map((p) => ({
+      position: p.body.translation(),
+      rotation: p.body.rotation(),
+    }));
+  }
+
+  function dispose() {
+    for (const p of poops) {
+      if (p?.body) world.removeRigidBody(p.body);
+    }
+    poops.length = 0;
+    dynamic.length = 0;
+    scene.remove(mesh);
+    mesh.material.dispose();
+  }
+
+  return {
+    spawn,
+    update,
+    dispose,
+    getSnapshots,
+    get total() { return totalSpawned; },
+    get count() { return mesh.count; },
+  };
 }

--- a/poopopulous-3000/src/world.js
+++ b/poopopulous-3000/src/world.js
@@ -45,6 +45,8 @@ export function createWorld(container) {
   scene.add(sun);
 
   const half = (GRID_SIZE * TILE_SIZE) / 2;
+  const splashGroup = new THREE.Group();
+  scene.add(splashGroup);
 
   const ground = new THREE.Mesh(
     new THREE.BoxGeometry(GRID_SIZE * TILE_SIZE, 1, GRID_SIZE * TILE_SIZE),
@@ -52,11 +54,11 @@ export function createWorld(container) {
   );
   ground.position.y = -0.5;
   ground.receiveShadow = true;
-  scene.add(ground);
+  splashGroup.add(ground);
 
   const grid = new THREE.GridHelper(GRID_SIZE * TILE_SIZE, GRID_SIZE, 0x33502a, 0x4f7240);
   grid.position.y = 0.005;
-  scene.add(grid);
+  splashGroup.add(grid);
 
   // Hover highlight tile
   const highlight = new THREE.Mesh(
@@ -66,11 +68,16 @@ export function createWorld(container) {
   highlight.rotation.x = -Math.PI / 2;
   highlight.position.y = 0.01;
   highlight.visible = false;
-  scene.add(highlight);
+  splashGroup.add(highlight);
 
   const raycaster = new THREE.Raycaster();
   const pointer = new THREE.Vector2();
   window.addEventListener('pointermove', (e) => {
+    if (!splashGroup.visible) {
+      highlight.visible = false;
+      return;
+    }
+
     pointer.x = (e.clientX / window.innerWidth) * 2 - 1;
     pointer.y = -(e.clientY / window.innerHeight) * 2 + 1;
     raycaster.setFromCamera(pointer, camera);
@@ -101,5 +108,19 @@ export function createWorld(container) {
   document.getElementById('zoomInButton').addEventListener('click', () => zoomBy(1.2));
   document.getElementById('zoomOutButton').addEventListener('click', () => zoomBy(1 / 1.2));
 
-  return { scene, camera, renderer, controls };
+  function setSplashVisible(visible) {
+    splashGroup.visible = visible;
+    if (!visible) highlight.visible = false;
+  }
+
+  function setCameraHome({ position = [20, 20, 20], target = [0, 0, 0], zoom = 1 } = {}) {
+    camera.position.set(...position);
+    controls.target.set(...target);
+    camera.zoom = zoom;
+    camera.lookAt(controls.target);
+    camera.updateProjectionMatrix();
+    controls.update();
+  }
+
+  return { scene, splashGroup, camera, renderer, controls, setSplashVisible, setCameraHome };
 }


### PR DESCRIPTION
## Summary

Adds the first Level 1 flow simulation to Poopopulous 3000.

- Keeps the existing splash screen intact and adds a HUD path into Level 1.
- Adds randomized sloped Mario-style half-pipe layouts with pipe colliders, dead-end closures, spawn pipe, and a diner-style Poopopulous exit sign that tracks drained particles.
- Adds a particle-based poo flow simulation with chute spawning, backpressure, branch routing, fast/slow flow drag, floaters, and containment checks.
- Preserves the upstream massive pile culling/LOD work by first fast-forwarding the fork `main` to `jbfly/main`, then resolving conflicts before merging the feature into the fork.
- Expands the smoke test to cover splash, unleashed splash, karaoke, Level 1 dry mode, Level 1 flow, pipe routing validity, drag exchange, draining, and containment.

## Conflict handling

Before opening this upstream PR, the fork `main` was fast-forwarded to `jbfly/main` at `b619161` and the flow branch was merged against that updated base. Conflicts in `poopopulous-3000/src/main.js` and `poopopulous-3000/src/poops.js` were resolved locally, keeping upstream's pile LOD/culling behavior and the new mode-based Level 1 flow simulation.

## Validation

- `npm run build`
- `GAME_URL=http://127.0.0.1:5174/ node scripts/smoke-test.mjs`

Smoke result after conflict resolution: no console errors, Level 1 drained 276 particles, drag/entrainment metrics were active, and `outsidePipeCount` stayed 0.